### PR TITLE
日記にリアクションができるように-バックエンド

### DIFF
--- a/React/unknwon-react-diary/src/component/FetchDiary.js
+++ b/React/unknwon-react-diary/src/component/FetchDiary.js
@@ -40,6 +40,31 @@ const DiaryFetch = () => {
       });
   };
 
+  const upadteDiary = async () => {
+    const apiName = 'UPDATEDiaryAPIDev';
+    const path = '';
+
+    const postData = {
+      id: diary.id,
+      post_at: diary.post_at,
+    };
+    const myInit = {
+      headers: {
+        Authorization: `Bearer ${(await Auth.currentSession()).getIdToken().getJwtToken()}`,
+      },
+      body: postData,
+      contentType: 'application/json',
+    };
+
+    await API.post(apiName, path, myInit)
+      .then(() => {
+        console.log('成功');
+      })
+      .catch((err) => {
+        console.log(err);
+      });
+  };
+
   return (
     <Container style={{ marginTop: '20px' }} maxWidth="md">
       <Grid container>
@@ -69,6 +94,9 @@ const DiaryFetch = () => {
       />
       <Button variant="contained" color="primary" onClick={() => fetchDiary()}>
         日記を取得
+      </Button>
+      <Button variant="contained" color="primary" onClick={() => upadteDiary()}>
+        日記に反応する
       </Button>
     </Container>
   );

--- a/React/unknwon-react-diary/src/component/FetchDiary.js
+++ b/React/unknwon-react-diary/src/component/FetchDiary.js
@@ -95,9 +95,9 @@ const DiaryFetch = () => {
       <Button variant="contained" color="primary" onClick={() => fetchDiary()}>
         日記を取得
       </Button>
-      {/* <Button variant="contained" color="primary" onClick={() => upadteDiary()}>
+      <Button variant="contained" color="primary" onClick={() => upadteDiary()}>
         日記に反応する
-      </Button> */}
+      </Button>
     </Container>
   );
 };

--- a/React/unknwon-react-diary/src/component/FetchDiary.js
+++ b/React/unknwon-react-diary/src/component/FetchDiary.js
@@ -95,9 +95,9 @@ const DiaryFetch = () => {
       <Button variant="contained" color="primary" onClick={() => fetchDiary()}>
         日記を取得
       </Button>
-      <Button variant="contained" color="primary" onClick={() => upadteDiary()}>
+      {/* <Button variant="contained" color="primary" onClick={() => upadteDiary()}>
         日記に反応する
-      </Button>
+      </Button> */}
     </Container>
   );
 };

--- a/React/unknwon-react-diary/src/index.js
+++ b/React/unknwon-react-diary/src/index.js
@@ -49,6 +49,11 @@ Amplify.configure({
         region: 'ap-northeast-1',
       },
       {
+        name: 'UPDATEDiaryAPIDev',
+        endpoint: 'https://c3xw1225c3.execute-api.ap-northeast-1.amazonaws.com/dev/reaction',
+        region: 'ap-northeast-1',
+      },
+      {
         name: 'POSTStoreAPIProd',
         endpoint: 'https://n1ek4zl4n9.execute-api.ap-northeast-1.amazonaws.com/prod/post',
         region: 'ap-northeast-1',

--- a/backend/comconfirm-lambda/Makefile
+++ b/backend/comconfirm-lambda/Makefile
@@ -7,7 +7,7 @@ GO_LDFLAGS  = -ldflags="-s -w"
 GOOS        = linux
 
 ### ターゲットパラメーター
-TARGETS = bin/receiver bin/getter bin/getter-my-diaries
+TARGETS = bin/receiver bin/getter bin/getter-my-diaries bin/reaction-diary
 
 ### 環境 dev or prod prodの場合は 手動で指定
 STAGE=dev
@@ -31,4 +31,7 @@ bin/getter: functions/diary-getter/main.go
 	GOOS=$(GOOS) $(GO_BUILD) $(GO_LDFLAGS) -o $@ $<
 
 bin/getter-my-diaries: functions/diary-my-getter/main.go
+	GOOS=$(GOOS) $(GO_BUILD) $(GO_LDFLAGS) -o $@ $<
+
+bin/reaction-diary: functions/diary-reaction/main.go
 	GOOS=$(GOOS) $(GO_BUILD) $(GO_LDFLAGS) -o $@ $<

--- a/backend/comconfirm-lambda/functions/diary-getter/controller/getter-controller.go
+++ b/backend/comconfirm-lambda/functions/diary-getter/controller/getter-controller.go
@@ -14,7 +14,7 @@ type GetterController struct {
 }
 
 // Run - usecase 上の GetterJob 経由で処理する
-func (c *GetterController) Run(ctx context.Context) (usecase.ResultDiaryContent, error) {
+func (c *GetterController) Run(ctx context.Context) (usecase.ResultDiary, error) {
 	gj := usecase.GetterJob{
 		DynamoDBClientRepo: c.DynamoDBClientRepo,
 		DiaryGetter:        c.DiaryGetter,

--- a/backend/comconfirm-lambda/functions/diary-getter/domain/get-diary.go
+++ b/backend/comconfirm-lambda/functions/diary-getter/domain/get-diary.go
@@ -14,9 +14,10 @@ import (
 
 // Diary - 日記の内容を表現する構造体です
 type Diary struct {
-	ID      string // id
-	PostAt  string // ポストされた日時
-	Content string `json:"content"` // 日記の本文
+	ID       string // id
+	PostAt   string // ポストされた日時
+	Content  string // 日記の本文
+	Reaction string // 日記のリアクション
 }
 
 // GetDiary - 日記を表現する構造体です
@@ -78,6 +79,14 @@ func (gd *GetDiary) SetDiary(item map[string]*dynamodb.AttributeValue) (Diary, e
 	if err != nil {
 		fmt.Printf("failed to unmarshal post_data. input: %s", *item["post_data"])
 		return diary, err
+	}
+
+	// リアクションがない場合とある場合で条件分岐
+	reaction, ok := item["reaction"]
+	if !ok {
+		diary.Reaction = "0"
+	} else {
+		diary.Reaction = *reaction.S
 	}
 
 	diary.ID = *item["id"].S

--- a/backend/comconfirm-lambda/functions/diary-getter/usecase/getter-job.go
+++ b/backend/comconfirm-lambda/functions/diary-getter/usecase/getter-job.go
@@ -16,8 +16,10 @@ type GetterJob struct {
 	diary *domain.GetDiary
 }
 
-// ResultDiaryContent はAPIのresponse内に格納する日記の内容を格納する構造体です
-type ResultDiaryContent struct {
+// ResultDiary はAPIのresponse内に格納する日記の内容を格納する構造体です
+type ResultDiary struct {
+	ID           string `json:"id"`
+	PostAt       string `json:"post_at"`
 	DiaryContent string `json:"diary_content"`
 }
 
@@ -53,18 +55,20 @@ func (gj *GetterJob) featchDiary(ctx context.Context) (domain.Diary, error) {
 // recevier を変更する
 
 // Run は実際の処理を行うメソッドです
-func (gj *GetterJob) Run(ctx context.Context) (ResultDiaryContent, error) {
+func (gj *GetterJob) Run(ctx context.Context) (ResultDiary, error) {
 	var err error
 
-	resultDiaryContent := ResultDiaryContent{}
+	ResultDiary := ResultDiary{}
 
 	getItem, err := gj.featchDiary(ctx)
 	if err != nil {
 		fmt.Printf("getItem: %v \n", err)
 	}
 
-	resultDiaryContent.DiaryContent = getItem.Content
+	ResultDiary.ID = getItem.ID
+	ResultDiary.PostAt = getItem.PostAt
+	ResultDiary.DiaryContent = getItem.Content
 
-	return resultDiaryContent, nil
+	return ResultDiary, nil
 
 }

--- a/backend/comconfirm-lambda/functions/diary-getter/usecase/getter-job.go
+++ b/backend/comconfirm-lambda/functions/diary-getter/usecase/getter-job.go
@@ -21,6 +21,7 @@ type ResultDiary struct {
 	ID           string `json:"id"`
 	PostAt       string `json:"post_at"`
 	DiaryContent string `json:"diary_content"`
+	Reaction     string `json:"reaction"`
 }
 
 func (gj *GetterJob) featchDiary(ctx context.Context) (domain.Diary, error) {
@@ -52,8 +53,6 @@ func (gj *GetterJob) featchDiary(ctx context.Context) (domain.Diary, error) {
 	return domain.Diary{}, err
 }
 
-// recevier を変更する
-
 // Run は実際の処理を行うメソッドです
 func (gj *GetterJob) Run(ctx context.Context) (ResultDiary, error) {
 	var err error
@@ -68,6 +67,7 @@ func (gj *GetterJob) Run(ctx context.Context) (ResultDiary, error) {
 	ResultDiary.ID = getItem.ID
 	ResultDiary.PostAt = getItem.PostAt
 	ResultDiary.DiaryContent = getItem.Content
+	ResultDiary.Reaction = getItem.Reaction
 
 	return ResultDiary, nil
 

--- a/backend/comconfirm-lambda/functions/diary-my-getter/domain/get-my-diary.go
+++ b/backend/comconfirm-lambda/functions/diary-my-getter/domain/get-my-diary.go
@@ -11,9 +11,10 @@ import (
 
 // Diary - 各日記の内容を格納する構造体
 type Diary struct {
-	ID      string `json:"id"`      // id
-	PostAt  string `json:"post_at"` // ポストされた日時
-	Content string `json:"content"` // 日記の本文
+	ID       string `json:"id"`      // id
+	PostAt   string `json:"post_at"` // ポストされた日時
+	Content  string `json:"content"` // 日記の本文
+	Reaction string `json:"reaction"`
 }
 
 // GetDiaries - 日記を格納する構造体
@@ -72,6 +73,14 @@ func (gd *GetDiaries) AddDiaries(res *dynamodb.QueryOutput) ([]Diary, error) {
 		if err != nil {
 			fmt.Printf("failed to unmarshal post_data. input: %s", *item["post_data"])
 			continue
+		}
+
+		// リアクションがあるかどうかで条件分岐
+		reaction, ok := item["reaction"]
+		if !ok {
+			diary.Reaction = "0"
+		} else {
+			diary.Reaction = *reaction.S
 		}
 
 		diary.ID = *item["id"].S

--- a/backend/comconfirm-lambda/functions/diary-reaction/adapter/adapter.go
+++ b/backend/comconfirm-lambda/functions/diary-reaction/adapter/adapter.go
@@ -1,0 +1,13 @@
+package adapter
+
+import (
+	"github.com/aws/aws-sdk-go/service/dynamodb"
+	"github.com/aws/aws-sdk-go/service/dynamodb/expression"
+)
+
+// DynamoDBClientRepository - DynamoDBを操作するためのインタフェース
+// infraから使用するメソッドを列挙
+type DynamoDBClientRepository interface {
+	Query(input *dynamodb.QueryInput) (*dynamodb.QueryOutput, error)
+	UpdateItem(item map[string]*dynamodb.AttributeValue, expr *expression.Expression) (*dynamodb.UpdateItemOutput, error)
+}

--- a/backend/comconfirm-lambda/functions/diary-reaction/adapter/adapter.go
+++ b/backend/comconfirm-lambda/functions/diary-reaction/adapter/adapter.go
@@ -8,6 +8,6 @@ import (
 // DynamoDBClientRepository - DynamoDBを操作するためのインタフェース
 // infraから使用するメソッドを列挙
 type DynamoDBClientRepository interface {
-	Query(input *dynamodb.QueryInput) (*dynamodb.QueryOutput, error)
+	QueryByExpressionNoindex(expr *expression.Expression) (*dynamodb.QueryOutput, error)
 	UpdateItem(item map[string]*dynamodb.AttributeValue, expr *expression.Expression) (*dynamodb.UpdateItemOutput, error)
 }

--- a/backend/comconfirm-lambda/functions/diary-reaction/controller/reaction-controller.go
+++ b/backend/comconfirm-lambda/functions/diary-reaction/controller/reaction-controller.go
@@ -1,0 +1,29 @@
+package controller
+
+import (
+	"context"
+
+	"github.com/aws/aws-lambda-go/events"
+	"github.com/s-amano/unknown-diary/backend/comconfirm-lambda/functions/diary-reaction/adapter"
+	"github.com/s-amano/unknown-diary/backend/comconfirm-lambda/functions/diary-reaction/usecase"
+)
+
+// ReactionController は コントローラーを表現する構造体です
+type ReactionController struct {
+	DynamoDBClientRepo adapter.DynamoDBClientRepository
+	DiaryReactioner    string
+}
+
+// Run - usecase 上の ReactionJob 経由でメッセージを処理する
+func (c *ReactionController) Run(ctx context.Context, apiGWEvent events.APIGatewayProxyRequest, result *events.APIGatewayProxyResponse) error {
+	srj := usecase.ReactionJob{
+		DynamoDBClientRepo: c.DynamoDBClientRepo,
+		DiaryReactioner:    c.DiaryReactioner,
+	}
+
+	err := srj.Run(ctx, apiGWEvent, result)
+	if err != nil {
+		return err
+	}
+	return nil
+}

--- a/backend/comconfirm-lambda/functions/diary-reaction/domain/reaction-diary.go
+++ b/backend/comconfirm-lambda/functions/diary-reaction/domain/reaction-diary.go
@@ -1,33 +1,138 @@
 package domain
 
 import (
+	"encoding/json"
 	"fmt"
 
 	"github.com/aws/aws-lambda-go/events"
+	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/dynamodb"
+	"github.com/aws/aws-sdk-go/service/dynamodb/expression"
 	"github.com/s-amano/unknown-diary/backend/comconfirm-lambda/functions/diary-reaction/adapter"
+
+	"strconv"
 )
+
+// PostDiary 該当の日記を取得するための構造体です
+type PostDiary struct {
+	Body     string
+	PostForm interface{}
+}
 
 // ReactionDiary 更新用の日記内容を表現する構造体です
 type ReactionDiary struct {
-	ID              string // id
-	PostAt          string // ポストされた日時
-	Reaction        string // 日記の反応
-	DiaryReactioner string
+	ID             string // id
+	PostAt         string // ポストされた日時
+	ThisReactioner string // 今回反応をした人
+	Reaction       string // 日記の反応
+	Reactioners    string // 日記に反応した人一覧
 }
 
-// NewReactionDiary - API Gateway のリクエスト情報から ReactionDiary オブジェクトを生成
-func NewReactionDiary(request events.APIGatewayProxyRequest, author string) (*ReactionDiary, error) {
+// NewPostDiary - API Gateway のリクエスト情報から PostDiary オブジェクトを生成
+func NewPostDiary(request events.APIGatewayProxyRequest) (*PostDiary, error) {
 	var err error
 
-	result := &ReactionDiary{}
-	fmt.Println(result)
-	return nil, err
+	result := &PostDiary{}
+
+	result.Body = request.Body
+
+	fmt.Printf("request.Body: %+v\n", request.Body)
+
+	// BODY 文字列をパースし PostForm に変換
+	if err = json.Unmarshal([]byte(result.Body), &result.PostForm); err != nil {
+		return nil, err
+	}
+	fmt.Printf("postForm: %+v\n", result.PostForm)
+
+	return result, err
 }
 
 // FetchOneDiaryFromDynamoDB - dynamoDBから特定の日記を取得する
-func (rd *ReactionDiary) FetchOneDiaryFromDynamoDB(dc adapter.DynamoDBClientRepository) (map[string]*dynamodb.AttributeValue, error) {
+func (rd *ReactionDiary) FetchOneDiaryFromDynamoDB(dc adapter.DynamoDBClientRepository, postDiary *PostDiary) error {
 	var err error
 
-	return nil, err
+	switch postForm := postDiary.PostForm.(type) {
+	case map[string]interface{}:
+		rd.ID = postForm["id"].(string)
+		rd.PostAt = postForm["post_at"].(string)
+	default:
+		fmt.Printf("postDiary.PostFormの型にミスがあります : %T\n", postDiary.PostForm)
+	}
+
+	// キー条件の生成
+	keyCond := expression.KeyAnd(
+		expression.Key("id").Equal(expression.Value(rd.ID)),
+		expression.Key("post_at").GreaterThan(expression.Value(rd.PostAt)),
+	)
+
+	// クエリ用 expression の生成
+	expr, err := expression.NewBuilder().WithKeyCondition(keyCond).Build()
+	if err != nil {
+		fmt.Printf("exp create err %v\n", err)
+		return err
+	}
+
+	res, err := dc.QueryByExpressionNoindex(&expr)
+	if err != nil {
+		return err
+	}
+
+	rd.Reactioners = *res.Items[0]["reactioners"].S
+	// reactionカラムがなかった時の処理
+
+	rd.Reaction = *res.Items[0]["reaction"].N
+	// reactionカラムがなかった時の処理
+
+	return nil
+}
+
+// DetermineAlreadyReaction - すでにリアクションしたかどうかを判定する
+func (rd *ReactionDiary) DetermineAlreadyReaction(dc adapter.DynamoDBClientRepository) error {
+	var err error
+	return err
+}
+
+// GetDynamoDBItemMap - updateするitemの特定をするためにプライマリーキー情報を生成します
+func (rd *ReactionDiary) GetDynamoDBItemMap() (map[string]*dynamodb.AttributeValue, error) {
+	// DynamoDB に格納する item オブジェクトを生成
+	item := map[string]*dynamodb.AttributeValue{
+		"id": {
+			S: aws.String(rd.ID),
+		},
+		"post_at": {
+			N: aws.String(rd.PostAt),
+		},
+	}
+	return item, nil
+}
+
+// UpdateDiaryReaction 日記の反応をアップデートする
+func (rd *ReactionDiary) UpdateDiaryReaction(item map[string]*dynamodb.AttributeValue, dc adapter.DynamoDBClientRepository) error {
+	var err error
+
+	// 反応を+1する
+	IntReaction, err := strconv.Atoi(rd.Reaction)
+	if err != nil {
+		return err
+	}
+	IntReaction++
+	rd.Reaction = strconv.Itoa(IntReaction)
+
+	// 反応者に名前を追加する
+	rd.Reactioners += rd.ThisReactioner
+
+	// 更新情報をitemとして生成
+	updateItem := expression.UpdateBuilder{}.Set(expression.Name("reaction"), expression.Value(rd.Reaction)).Set(expression.Name("reactioners"), expression.Value(rd.Reactioners))
+
+	expr, err := expression.NewBuilder().WithUpdate(updateItem).Build()
+	if err != nil {
+		return err
+	}
+
+	_, err = dc.UpdateItem(item, &expr)
+	if err != nil {
+		return err
+	}
+
+	return nil
 }

--- a/backend/comconfirm-lambda/functions/diary-reaction/domain/reaction-diary.go
+++ b/backend/comconfirm-lambda/functions/diary-reaction/domain/reaction-diary.go
@@ -1,0 +1,33 @@
+package domain
+
+import (
+	"fmt"
+
+	"github.com/aws/aws-lambda-go/events"
+	"github.com/aws/aws-sdk-go/service/dynamodb"
+	"github.com/s-amano/unknown-diary/backend/comconfirm-lambda/functions/diary-reaction/adapter"
+)
+
+// ReactionDiary 更新用の日記内容を表現する構造体です
+type ReactionDiary struct {
+	ID              string // id
+	PostAt          string // ポストされた日時
+	Reaction        string // 日記の反応
+	DiaryReactioner string
+}
+
+// NewReactionDiary - API Gateway のリクエスト情報から ReactionDiary オブジェクトを生成
+func NewReactionDiary(request events.APIGatewayProxyRequest, author string) (*ReactionDiary, error) {
+	var err error
+
+	result := &ReactionDiary{}
+	fmt.Println(result)
+	return nil, err
+}
+
+// FetchOneDiaryFromDynamoDB - dynamoDBから特定の日記を取得する
+func (rd *ReactionDiary) FetchOneDiaryFromDynamoDB(dc adapter.DynamoDBClientRepository) (map[string]*dynamodb.AttributeValue, error) {
+	var err error
+
+	return nil, err
+}

--- a/backend/comconfirm-lambda/functions/diary-reaction/domain/reaction-diary.go
+++ b/backend/comconfirm-lambda/functions/diary-reaction/domain/reaction-diary.go
@@ -26,10 +26,11 @@ type ReactionDiary struct {
 	ThisReactioner string // 今回反応をした人
 	Reaction       string // 日記の反応
 	Reactioners    string // 日記に反応した人一覧
+	Content        string // 日記の内容
 }
 
 // NewPostDiary - API Gateway のリクエスト情報から PostDiary オブジェクトを生成
-func NewPostDiary(request events.APIGatewayProxyRequest) (*PostDiary, error) {
+func NewPostDiary(request events.APIGatewayProxyRequest, diaryReactioner string) (*PostDiary, error) {
 	var err error
 
 	result := &PostDiary{}
@@ -119,7 +120,7 @@ func (rd *ReactionDiary) UpdateDiaryReaction(item map[string]*dynamodb.Attribute
 	rd.Reaction = strconv.Itoa(IntReaction)
 
 	// 反応者に名前を追加する
-	rd.Reactioners += rd.ThisReactioner
+	rd.Reactioners += "," + rd.ThisReactioner
 
 	// 更新情報をitemとして生成
 	updateItem := expression.UpdateBuilder{}.Set(expression.Name("reaction"), expression.Value(rd.Reaction)).Set(expression.Name("reactioners"), expression.Value(rd.Reactioners))

--- a/backend/comconfirm-lambda/functions/diary-reaction/domain/reaction-diary.go
+++ b/backend/comconfirm-lambda/functions/diary-reaction/domain/reaction-diary.go
@@ -27,6 +27,7 @@ type ReactionDiary struct {
 	Reaction       string // 日記の反応
 	Reactioners    string // 日記に反応した人一覧
 	Content        string // 日記の内容
+	ReactionFlag   bool   // 該当の日記にすでに反応があるかどうかのフラグ
 }
 
 // NewPostDiary - API Gateway のリクエスト情報から PostDiary オブジェクトを生成
@@ -79,11 +80,17 @@ func (rd *ReactionDiary) FetchOneDiaryFromDynamoDB(dc adapter.DynamoDBClientRepo
 
 	fmt.Printf("res + %+v\n", res)
 
-	rd.Reactioners = *res.Items[0]["reactioners"].S
-	// reactionカラムがなかった時の処理
+	item := res.Items[0]
 
-	rd.Reaction = *res.Items[0]["reaction"].S
-	// reactionカラムがなかった時の処理
+	reactioners, ok := item["reactioners"]
+	if !ok {
+		rd.Reaction = "0"
+		rd.Reactioners = ""
+		fmt.Printf("既存リアクションがない")
+	} else {
+		rd.Reactioners = *reactioners.S
+		rd.Reaction = *item["reaction"].S
+	}
 
 	return nil
 }

--- a/backend/comconfirm-lambda/functions/diary-reaction/domain/reaction-diary.go
+++ b/backend/comconfirm-lambda/functions/diary-reaction/domain/reaction-diary.go
@@ -61,10 +61,9 @@ func (rd *ReactionDiary) FetchOneDiaryFromDynamoDB(dc adapter.DynamoDBClientRepo
 	}
 
 	// キー条件の生成
-	keyCond := expression.KeyAnd(
-		expression.Key("id").Equal(expression.Value(rd.ID)),
-		expression.Key("post_at").GreaterThan(expression.Value(rd.PostAt)),
-	)
+	keyCond := expression.Key("id").Equal(expression.Value(rd.ID))
+
+	fmt.Printf("ID: %v\n", rd.ID)
 
 	// クエリ用 expression の生成
 	expr, err := expression.NewBuilder().WithKeyCondition(keyCond).Build()
@@ -78,10 +77,12 @@ func (rd *ReactionDiary) FetchOneDiaryFromDynamoDB(dc adapter.DynamoDBClientRepo
 		return err
 	}
 
+	fmt.Printf("res + %+v\n", res)
+
 	rd.Reactioners = *res.Items[0]["reactioners"].S
 	// reactionカラムがなかった時の処理
 
-	rd.Reaction = *res.Items[0]["reaction"].N
+	rd.Reaction = *res.Items[0]["reaction"].S
 	// reactionカラムがなかった時の処理
 
 	return nil

--- a/backend/comconfirm-lambda/functions/diary-reaction/main.go
+++ b/backend/comconfirm-lambda/functions/diary-reaction/main.go
@@ -1,0 +1,68 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"os"
+
+	"github.com/aws/aws-lambda-go/events"
+	"github.com/aws/aws-lambda-go/lambda"
+
+	"github.com/s-amano/unknown-diary/backend/comconfirm-lambda/functions/diary-reaction/controller"
+	"github.com/s-amano/unknown-diary/infra/dynamodbclient"
+)
+
+const (
+	envNameDiaryStoreDynamoDBTable = "DIARY_STORE_DYNAMODB_TABLE"
+)
+
+var (
+	region                  string
+	dynamoDBClient          *dynamodbclient.DynamoDBClient
+	diaryStoreDynamoDBTable string
+	reactioner              string
+)
+
+func init() {
+	region = "ap-northeast-1"
+
+	diaryStoreDynamoDBTable = os.Getenv(envNameDiaryStoreDynamoDBTable)
+
+	// DynamoDB クライアントの初期化
+	dynamoDBClient = dynamodbclient.NewDynamoDBClient(region, diaryStoreDynamoDBTable)
+}
+
+func handler(ctx context.Context, apiGWEvent events.APIGatewayProxyRequest) (events.APIGatewayProxyResponse, error) {
+	result := events.APIGatewayProxyResponse{
+		StatusCode: 200,
+		Headers: map[string]string{
+			"Content-Type":                     "text/html",
+			"Access-Control-Allow-Origin":      "*",
+			"Access-Control-Allow-Credentials": "true",
+		},
+		Body:            "",
+		IsBase64Encoded: false,
+	}
+
+	// POSTしたユーザー名取得
+	reactioner = apiGWEvent.RequestContext.Authorizer["claims"].(map[string]interface{})["cognito:username"].(string)
+
+	fmt.Printf("reactioner: %v", reactioner)
+
+	// コントローラの作成
+	src := controller.ReactionController{
+		DynamoDBClientRepo: dynamoDBClient,
+		DiaryReactioner:    reactioner,
+	}
+	// DynamoDB への書き込み
+	err := src.Run(context.Background(), apiGWEvent, &result)
+	if err != nil {
+		fmt.Printf("%s\n", err)
+	}
+
+	return result, err
+}
+
+func main() {
+	lambda.Start(handler)
+}

--- a/backend/comconfirm-lambda/functions/diary-reaction/usecase/reaction-job.go
+++ b/backend/comconfirm-lambda/functions/diary-reaction/usecase/reaction-job.go
@@ -1,0 +1,59 @@
+package usecase
+
+import (
+	"context"
+
+	"github.com/aws/aws-lambda-go/events"
+	"github.com/s-amano/unknown-diary/backend/comconfirm-lambda/functions/diary-reaction/adapter"
+	"github.com/s-amano/unknown-diary/backend/comconfirm-lambda/functions/diary-reaction/domain"
+)
+
+// ReactionJob ジョブを表すレポジトリです
+type ReactionJob struct {
+	DynamoDBClientRepo adapter.DynamoDBClientRepository
+	DiaryReactioner    string
+
+	diary *domain.ReactionDiary
+}
+
+// ResultDiary はAPIのresponse内に格納する日記を格納する構造体です
+type ResultDiary struct {
+	DiaryContent  string `json:"diary_content"`
+	DiaryReaction int    `json:"diary_reaction"`
+}
+
+// Run メソッドは、受け取ったポストデータを実際に処理します
+func (rj *ReactionJob) Run(ctx context.Context, apiGWEvent events.APIGatewayProxyRequest, result *events.APIGatewayProxyResponse) error {
+	var err error
+
+	// apiGWEvent のヘッダ、queryString から PostDiary 構造体を生成
+	diaryPost, err := domain.NewPostDiary(apiGWEvent, rj.DiaryReactioner)
+	if err != nil {
+		return err
+	}
+
+	// GetDiary を初期化
+	rj.diary = &domain.ReactionDiary{
+		ThisReactioner: rj.DiaryReactioner,
+	}
+
+	// DynamoDB からitemを取得
+	err = rj.diary.FetchOneDiaryFromDynamoDB(rj.DynamoDBClientRepo, diaryPost)
+	if err != nil {
+		return err
+	}
+
+	// updateするためのitem作成
+	item, err := rj.diary.GetDynamoDBItemMap()
+	if err != nil {
+		return err
+	}
+
+	// updateを実行
+	err = rj.diary.UpdateDiaryReaction(item, rj.DynamoDBClientRepo)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/backend/comconfirm-lambda/functions/diary-receiver/controller/receiver-controller.go
+++ b/backend/comconfirm-lambda/functions/diary-receiver/controller/receiver-controller.go
@@ -14,7 +14,7 @@ type ReceiverController struct {
 	Author             string
 }
 
-// Run - usecase 上の SurveyReceiverJob 経由でメッセージを処理する
+// Run - usecase 上の ReceiverJob 経由でメッセージを処理する
 func (c *ReceiverController) Run(ctx context.Context, apiGWEvent events.APIGatewayProxyRequest, result *events.APIGatewayProxyResponse) error {
 	srj := usecase.ReceiverJob{
 		DynamoDBRepo: c.DynamoDBClientRepo,

--- a/backend/comconfirm-lambda/functions/diary-receiver/domain/post-diary.go
+++ b/backend/comconfirm-lambda/functions/diary-receiver/domain/post-diary.go
@@ -51,6 +51,7 @@ func NewPost(request events.APIGatewayProxyRequest, author string) (*Post, error
 	}
 
 	fmt.Printf("postForm: %+v\n", result.PostForm)
+	fmt.Printf("postForm type: %T\n", result.PostForm)
 
 	// author　をセット
 	result.Author = author

--- a/backend/comconfirm-lambda/functions/diary-receiver/domain/post-diary.go
+++ b/backend/comconfirm-lambda/functions/diary-receiver/domain/post-diary.go
@@ -110,6 +110,12 @@ func (p *Post) GetDynamoDBItemMap() map[string]*dynamodb.AttributeValue {
 		"status_post_at": {
 			S: aws.String(statusPostAt),
 		},
+		"reaction": {
+			S: aws.String("0"),
+		},
+		"reactioners": {
+			S: aws.String(""),
+		},
 	}
 
 	return item

--- a/backend/comconfirm-lambda/functions/diary-receiver/usecase/receiver-job.go
+++ b/backend/comconfirm-lambda/functions/diary-receiver/usecase/receiver-job.go
@@ -21,7 +21,7 @@ type ReceiverJob struct {
 func (c *ReceiverJob) Run(ctx context.Context, apiGWEvent events.APIGatewayProxyRequest, result *events.APIGatewayProxyResponse) error {
 	var err error
 
-	// apiGWEvent のヘッダ、queryString から SurveyPost 構造体を生成
+	// apiGWEvent のヘッダ、queryString から Post 構造体を生成
 	post, err := domain.NewPost(apiGWEvent, c.Author)
 	if err != nil {
 		return err

--- a/backend/comconfirm-lambda/resources/reaction-diary.yml
+++ b/backend/comconfirm-lambda/resources/reaction-diary.yml
@@ -1,0 +1,11 @@
+reaction:
+  handler: bin/reaction
+  name: '${self:service}-${self:provider.stage}-reaction'
+  events:
+    # API Gateway にて起動
+    - http:
+        path: /reaction
+        method: post
+        authorizer:
+          type: COGNITO_USER_POOLS
+          authorizerId: !Ref UnknownDiaryAuthorizer

--- a/backend/comconfirm-lambda/resources/reaction-diary.yml
+++ b/backend/comconfirm-lambda/resources/reaction-diary.yml
@@ -1,6 +1,6 @@
-reaction:
-  handler: bin/reaction
-  name: '${self:service}-${self:provider.stage}-reaction'
+reaction-diary:
+  handler: bin/reaction-diary
+  name: '${self:service}-${self:provider.stage}-reaction-diary'
   events:
     # API Gateway にて起動
     - http:

--- a/backend/comconfirm-lambda/serverless.yml
+++ b/backend/comconfirm-lambda/serverless.yml
@@ -55,6 +55,7 @@ functions:
   - ${file(./resources/receiver.yml)}
   - ${file(./resources/getter.yml)}
   - ${file(./resources/getter-my-diaries.yml)}
+  - ${file(./resources/reaction-diary.yml)}
 
 resources:
   - ${file(./resources/dynamodb.yml)}

--- a/infra/dynamodbclient/client.go
+++ b/infra/dynamodbclient/client.go
@@ -58,6 +58,19 @@ func (c *DynamoDBClient) QueryByExpression(indexName string, expr *expression.Ex
 	return c.dynamo.Query(q)
 }
 
+// QueryByExpressionNoindex 検索してレコードを取得する関数(indexをデフォルトのものを使う)
+func (c *DynamoDBClient) QueryByExpressionNoindex(expr *expression.Expression) (*dynamodb.QueryOutput, error) {
+	q := &dynamodb.QueryInput{
+		ExpressionAttributeNames:  expr.Names(),
+		ExpressionAttributeValues: expr.Values(),
+		FilterExpression:          expr.Filter(),
+		KeyConditionExpression:    expr.KeyCondition(),
+		ProjectionExpression:      expr.Projection(),
+		TableName:                 aws.String(c.tableName),
+	}
+	return c.dynamo.Query(q)
+}
+
 // PutItem dynamoDBにデータをPUTする関数
 func (c *DynamoDBClient) PutItem(item map[string]*dynamodb.AttributeValue) (*dynamodb.PutItemOutput, error) {
 	p := &dynamodb.PutItemInput{


### PR DESCRIPTION
# 目的
- 日記にリアクションをつけることで日記をpostしてもらいやすくしたい

# やったこと
- [x] 日記にリアクションをつけるLambda関数を新たに作成
- [x] 既存のgetter関数において、reactionを取得するように修正
- [x] 既存のreceiver関数において、初期値としてreaction,reactionersカラムを用意
- [x] 既存の日記で、リアクションカラムがないレコードへのハンドリングを追加

# 特記事項
- テストコードまだ書いてない
- 現状は、同一ユーザーが同一日記に何回もリアクションできる状態なのでこれは修正したい