### PR TITLE
リアクション機能(フロント)

### DIFF
--- a/React/unknwon-react-diary/src/component/FetchDiary.js
+++ b/React/unknwon-react-diary/src/component/FetchDiary.js
@@ -6,6 +6,7 @@ import Container from '@material-ui/core/Container';
 import Typography from '@material-ui/core/Typography';
 import TextField from '@material-ui/core/TextField';
 import Button from '@material-ui/core/Button';
+import FavoriteIcon from '@material-ui/icons/Favorite';
 
 const DiaryFetch = () => {
   const [diary, setDiary] = useState({});
@@ -92,12 +93,18 @@ const DiaryFetch = () => {
         value={diary.diary_content}
         disabled
       />
-      <Button variant="contained" color="primary" onClick={() => fetchDiary()}>
-        日記を取得
-      </Button>
-      {/* <Button variant="contained" color="primary" onClick={() => upadteDiary()}>
-        日記に反応する
-      </Button> */}
+      <Grid container>
+        <Button variant="contained" color="primary" onClick={() => fetchDiary()}>
+          日記を取得
+        </Button>
+      </Grid>
+
+      <Grid container justify="flex-end">
+        <Button variant="contained" color="primary" onClick={() => upadteDiary()}>
+          <FavoriteIcon color="error" />
+          {diary.reaction}
+        </Button>
+      </Grid>
     </Container>
   );
 };

--- a/React/unknwon-react-diary/src/component/FetchMyDiaries.js
+++ b/React/unknwon-react-diary/src/component/FetchMyDiaries.js
@@ -51,9 +51,9 @@ const FetchMyDiaries = () => {
     fetchMyDiaries();
   }, []);
 
-  const DetailMyDiary = (diaryContent) => {
-    console.log(diaryContent);
-    setMyDiaryDetail(diaryContent);
+  const DetailMyDiary = (diary) => {
+    console.log(diary);
+    setMyDiaryDetail(diary);
   };
 
   return (
@@ -70,7 +70,9 @@ const FetchMyDiaries = () => {
       </Typography>
       <List>
         {myDiaries.map((value) => {
+          const diary = {};
           const diaryContent = value.content;
+          const diaryReaction = value.reaction;
           const maxLength = 22;
           let modifiedDiaryContent = '';
           if (diaryContent.length > maxLength) {
@@ -79,11 +81,14 @@ const FetchMyDiaries = () => {
             modifiedDiaryContent = diaryContent;
           }
 
+          diary.diaryContent = diaryContent;
+          diary.diaryReaction = diaryReaction;
+
           return (
             <ListItem key={value.id} role={undefined} dense button>
               <ListItemText style={{ color: 'black', textOverflow: 'ellipsis' }}>{modifiedDiaryContent}</ListItemText>
               <ListItemSecondaryAction>
-                <Link to="/mydiary-detail" onClick={() => DetailMyDiary(diaryContent)}>
+                <Link to="/mydiary-detail" onClick={() => DetailMyDiary(diary)}>
                   <IconButton edge="end" aria-label="detail">
                     <DetailsIcon />
                   </IconButton>

--- a/React/unknwon-react-diary/src/component/MyDiaryDetail.js
+++ b/React/unknwon-react-diary/src/component/MyDiaryDetail.js
@@ -6,6 +6,7 @@ import TextField from '@material-ui/core/TextField';
 import { Grid } from '@material-ui/core';
 import Button from '@material-ui/core/Button';
 import { Link } from 'react-router-dom';
+import FavoriteIcon from '@material-ui/icons/Favorite';
 
 const MyDiaryDetail = () => {
   const { myDiaryDetail } = useContext(ApiContext);
@@ -21,7 +22,19 @@ const MyDiaryDetail = () => {
       <Typography style={{ marginTop: '30px', color: 'black', marginBottom: '10%' }} variant="h6">
         自分の日記の詳細
       </Typography>
-      <TextField style={{ width: '100%', marginBottom: '5%' }} multiline rows={20} value={myDiaryDetail} disabled />
+      <TextField
+        style={{ width: '100%', marginBottom: '5%' }}
+        multiline
+        rows={20}
+        value={myDiaryDetail.diaryContent}
+        disabled
+      />
+      <Grid container justify="flex-end">
+        <Button variant="contained" color="primary">
+          <FavoriteIcon color="error" />
+          {myDiaryDetail.diaryReaction}
+        </Button>
+      </Grid>
     </Container>
   );
 };


### PR DESCRIPTION
# 目的
- リアクションを取得し、表示させたい

# やったこと
- [x] 自分の日記の詳細ページでリアクションがどれくらいあるかを確認できる
- [x] 取得した日記に対してリアクションができる

# 特記事項
- バックエンドで値を更新したレスポンスとして同一日記を返してもらわないとフロントで更新されない。
- デザインがさすがにひどい