### PR TITLE
リアクションが即座に変更されるように修正

### DIFF
--- a/React/unknwon-react-diary/src/component/FetchDiary.js
+++ b/React/unknwon-react-diary/src/component/FetchDiary.js
@@ -58,8 +58,9 @@ const DiaryFetch = () => {
     };
 
     await API.post(apiName, path, myInit)
-      .then(() => {
+      .then((response) => {
         console.log('成功');
+        setDiary(response);
       })
       .catch((err) => {
         console.log(err);

--- a/backend/comconfirm-lambda/functions/diary-reaction/controller/reaction-controller.go
+++ b/backend/comconfirm-lambda/functions/diary-reaction/controller/reaction-controller.go
@@ -15,15 +15,15 @@ type ReactionController struct {
 }
 
 // Run - usecase 上の ReactionJob 経由でメッセージを処理する
-func (c *ReactionController) Run(ctx context.Context, apiGWEvent events.APIGatewayProxyRequest, result *events.APIGatewayProxyResponse) error {
+func (c *ReactionController) Run(ctx context.Context, apiGWEvent events.APIGatewayProxyRequest, result *events.APIGatewayProxyResponse) (usecase.ResultDiary, error) {
 	srj := usecase.ReactionJob{
 		DynamoDBClientRepo: c.DynamoDBClientRepo,
 		DiaryReactioner:    c.DiaryReactioner,
 	}
 
-	err := srj.Run(ctx, apiGWEvent, result)
+	resposeDiary, err := srj.Run(ctx, apiGWEvent, result)
 	if err != nil {
-		return err
+		return resposeDiary, err
 	}
-	return nil
+	return resposeDiary, nil
 }

--- a/backend/comconfirm-lambda/functions/diary-reaction/main.go
+++ b/backend/comconfirm-lambda/functions/diary-reaction/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"os"
 
@@ -55,10 +56,17 @@ func handler(ctx context.Context, apiGWEvent events.APIGatewayProxyRequest) (eve
 		DiaryReactioner:    reactioner,
 	}
 	// DynamoDB への書き込み
-	err := src.Run(context.Background(), apiGWEvent, &result)
+	responseDiary, err := src.Run(context.Background(), apiGWEvent, &result)
 	if err != nil {
 		fmt.Printf("%s\n", err)
 	}
+
+	j, err := json.Marshal(responseDiary)
+	if err != nil {
+		fmt.Printf("j作成 : %s\n", err)
+	}
+
+	result.Body = string(j)
 
 	return result, err
 }


### PR DESCRIPTION
# 目的
- 他人の日記を取得し、リアクションを押したら即座に更新して欲しい

# やったこと
- updateAPIのレスポンスとして更新した日記の情報をいれる
- フロント側からレスポンスを受け付けてstateを更新する

# 特記事項