### PR TITLE
リアクションボタンを押すと日記本文が削除されてしまうバグを解消

### DIFF
--- a/React/unknwon-react-diary/src/component/FetchDiary.js
+++ b/React/unknwon-react-diary/src/component/FetchDiary.js
@@ -11,7 +11,7 @@ import FavoriteIcon from '@material-ui/icons/Favorite';
 const DiaryFetch = () => {
   const [diary, setDiary] = useState({});
 
-  const envAPI = () => {
+  const envFetchAPI = () => {
     const env = process.env.REACT_APP_ENVIROMENT;
     console.log(env);
     if (env === 'prod') {
@@ -21,8 +21,18 @@ const DiaryFetch = () => {
     }
   };
 
+  const envUpdateAPI = () => {
+    const env = process.env.REACT_APP_ENVIROMENT;
+    console.log(env);
+    if (env === 'prod') {
+      return 'UPDATEDiaryAPIProd';
+    } else if (env === 'dev') {
+      return 'UPDATEDiaryAPIDev';
+    }
+  };
+
   const fetchDiary = async () => {
-    const apiName = envAPI();
+    const apiName = envFetchAPI();
     const path = '';
 
     const myInit = {
@@ -42,7 +52,7 @@ const DiaryFetch = () => {
   };
 
   const upadteDiary = async () => {
-    const apiName = 'UPDATEDiaryAPIDev';
+    const apiName = envUpdateAPI();
     const path = '';
 
     const postData = {
@@ -60,7 +70,7 @@ const DiaryFetch = () => {
     await API.post(apiName, path, myInit)
       .then((response) => {
         console.log('成功');
-        setDiary(response);
+        setDiary({ ...diary, reaction: response.reaction });
       })
       .catch((err) => {
         console.log(err);

--- a/React/unknwon-react-diary/src/index.js
+++ b/React/unknwon-react-diary/src/index.js
@@ -68,6 +68,11 @@ Amplify.configure({
         endpoint: 'https://n1ek4zl4n9.execute-api.ap-northeast-1.amazonaws.com/prod/get/mydiaries',
         region: 'ap-northeast-1',
       },
+      {
+        name: 'UPDATEDiaryAPIProd',
+        endpoint: 'https://n1ek4zl4n9.execute-api.ap-northeast-1.amazonaws.com/prod/reaction',
+        region: 'ap-northeast-1',
+      },
     ],
   },
 });

--- a/backend/comconfirm-lambda/functions/diary-reaction/domain/reaction-diary.go
+++ b/backend/comconfirm-lambda/functions/diary-reaction/domain/reaction-diary.go
@@ -146,7 +146,6 @@ func (rd *ReactionDiary) UpdateDiaryReaction(item map[string]*dynamodb.Attribute
 		ID:       rd.ID,
 		PostAt:   rd.PostAt,
 		Reaction: *responseitem["reaction"].S,
-		Content:  rd.Content,
 	}
 
 	fmt.Printf("updateItemのres : %+v\n", res.Attributes)

--- a/backend/comconfirm-lambda/functions/diary-reaction/usecase/reaction-job.go
+++ b/backend/comconfirm-lambda/functions/diary-reaction/usecase/reaction-job.go
@@ -18,10 +18,9 @@ type ReactionJob struct {
 
 // ResultDiary はAPIのresponse内に格納する日記を格納する構造体です
 type ResultDiary struct {
-	ID           string `json:"id"`
-	PostAt       string `json:"post_at"`
-	DiaryContent string `json:"diary_content"`
-	Reaction     string `json:"reaction"`
+	ID       string `json:"id"`
+	PostAt   string `json:"post_at"`
+	Reaction string `json:"reaction"`
 }
 
 // Run メソッドは、受け取ったポストデータを実際に処理します
@@ -60,7 +59,6 @@ func (rj *ReactionJob) Run(ctx context.Context, apiGWEvent events.APIGatewayProx
 	}
 	ResultDiary.ID = responseDiary.ID
 	ResultDiary.PostAt = responseDiary.PostAt
-	ResultDiary.DiaryContent = responseDiary.Content
 	ResultDiary.Reaction = responseDiary.Reaction
 
 	return ResultDiary, nil


### PR DESCRIPTION
# 目的
- リアクションボタンを押すと日記コンテンツが消えてしまうバグを直したい

# やったこと
- バックエンド側で日記コンテンツをレスポンスに入れない
- フロントでstate更新するのをリアクション数だけにした

# 特記事項
- バグの原因はバックエンドで日記のコンテンツが取れていなかった事。post_data取得からパースしてcontentにしなきゃいけなかった。
- そもそもidやpost_at,contentは更新する必要ないなと思い今回の形へ修正