### PR TITLE
日記を取得していないときはリアクションボタンを表示させない

### DIFF
--- a/React/unknwon-react-diary/src/component/FetchDiary.js
+++ b/React/unknwon-react-diary/src/component/FetchDiary.js
@@ -110,12 +110,16 @@ const DiaryFetch = () => {
         </Button>
       </Grid>
 
-      <Grid container justify="flex-end">
-        <Button variant="contained" color="primary" onClick={() => upadteDiary()}>
-          <FavoriteIcon color="error" />
-          {diary.reaction}
-        </Button>
-      </Grid>
+      {diary.reaction ? (
+        <Grid container justify="flex-end">
+          <Button variant="contained" color="primary" onClick={() => upadteDiary()}>
+            <FavoriteIcon color="error" />
+            {diary.reaction}
+          </Button>
+        </Grid>
+      ) : (
+        <></>
+      )}
     </Container>
   );
 };

--- a/backend/comconfirm-lambda/functions/diary-reaction/domain/reaction-diary.go
+++ b/backend/comconfirm-lambda/functions/diary-reaction/domain/reaction-diary.go
@@ -45,7 +45,7 @@ func NewPostDiary(request events.APIGatewayProxyRequest, diaryReactioner string)
 	}
 	fmt.Printf("postForm: %+v\n", result.PostForm)
 
-	return result, err
+	return result, nil
 }
 
 // FetchOneDiaryFromDynamoDB - dynamoDBから特定の日記を取得する


### PR DESCRIPTION
# 目的
- 日記を取得していないときにリアクションボタンを押すとエラーになるので、押せないようにしたい

# やったこと
- diary.reactionの値があるかどうかによってリアクションボタンを出すかださないかを処理

# 特記事項