### PR TITLE
自分の日記データを統計カードに表示

### DIFF
--- a/React/unknwon-react-diary/src/App.js
+++ b/React/unknwon-react-diary/src/App.js
@@ -6,7 +6,7 @@ import Login from './component/Login';
 import PostDiary from './component/PostDiary';
 import FetchDiary from './component/FetchDiary';
 import MyDiaryDetail from './component/MyDiaryDetail';
-import FetchMyDiaries from './component/FetchMyDiaries';
+import MyProfile from './component/MyProfile';
 import { Route, BrowserRouter } from 'react-router-dom';
 
 function App() {
@@ -17,7 +17,7 @@ function App() {
           <Login />
           <div className="App">
             <Navbar />
-            <Route exact path="/mydiary" component={FetchMyDiaries} />
+            <Route exact path="/mydiary" component={MyProfile} />
             <Route exact path="/mydiary-detail" component={MyDiaryDetail} />
             <Route exact path="/diary" component={FetchDiary} />
             <Route exact path="/" component={PostDiary} />

--- a/React/unknwon-react-diary/src/component/FetchMyDiaries.js
+++ b/React/unknwon-react-diary/src/component/FetchMyDiaries.js
@@ -1,6 +1,5 @@
-import React, { useContext, useEffect, useState } from 'react';
+import React, { useContext } from 'react';
 import { makeStyles } from '@material-ui/core/styles';
-import { Auth, API } from 'aws-amplify';
 import { ApiContext } from '../context/ApiContext';
 import Grid from '@material-ui/core/Grid';
 import IconButton from '@material-ui/core/IconButton';
@@ -28,44 +27,9 @@ const useStyles = makeStyles((theme) => ({
   },
 }));
 
-const FetchMyDiaries = () => {
+const FetchMyDiaries = (props) => {
   const classes = useStyles();
   const { setMyDiaryDetail } = useContext(ApiContext);
-  const [myDiaries, setMyDiaries] = useState([]);
-
-  useEffect(() => {
-    const envAPI = () => {
-      const env = process.env.REACT_APP_ENVIROMENT;
-      console.log(env);
-      if (env === 'prod') {
-        return 'GETMyDiariesAPIProd';
-      } else if (env === 'dev') {
-        return 'GETMyDiariesAPIDev';
-      }
-    };
-
-    const fetchMyDiaries = async () => {
-      const apiName = envAPI();
-      const path = '';
-
-      const myInit = {
-        headers: {
-          Authorization: `Bearer ${(await Auth.currentSession()).getIdToken().getJwtToken()}`,
-        },
-      };
-
-      await API.get(apiName, path, myInit)
-        .then((response) => {
-          console.log(response);
-          setMyDiaries(response.Diaries);
-        })
-        .catch((err) => {
-          console.log(err);
-        });
-    };
-
-    fetchMyDiaries();
-  }, []);
 
   const DetailMyDiary = (diary) => {
     console.log(diary);
@@ -74,7 +38,7 @@ const FetchMyDiaries = () => {
 
   return (
     <Container style={{ marginTop: '40px' }} maxWidth="md">
-      {myDiaries.map((value) => {
+      {props.myDiaries.map((value, key) => {
         const diary = {};
         const diaryContent = value.content;
         const diaryReaction = value.reaction;
@@ -90,7 +54,7 @@ const FetchMyDiaries = () => {
         diary.diaryReaction = diaryReaction;
 
         return (
-          <Grid container>
+          <Grid container key={key}>
             <Card className={classes.card}>
               <CardContent className={classes.cardContent}>
                 <Typography>{modifiedDiaryContent}</Typography>

--- a/React/unknwon-react-diary/src/component/FetchMyDiaries.js
+++ b/React/unknwon-react-diary/src/component/FetchMyDiaries.js
@@ -74,9 +74,6 @@ const FetchMyDiaries = () => {
 
   return (
     <Container style={{ marginTop: '40px' }} maxWidth="md">
-      <Typography style={{ marginTop: '30px', color: 'black', marginBottom: '10%' }} variant="h6">
-        貴方の日記
-      </Typography>
       {myDiaries.map((value) => {
         const diary = {};
         const diaryContent = value.content;

--- a/React/unknwon-react-diary/src/component/MyProfile.js
+++ b/React/unknwon-react-diary/src/component/MyProfile.js
@@ -1,0 +1,17 @@
+import React from 'react';
+import FetchMyDiaries from './FetchMyDiaries';
+import Container from '@material-ui/core/Container';
+import Typography from '@material-ui/core/Typography';
+
+const MyProfile = () => {
+  return (
+    <Container style={{ marginTop: '40px' }} maxWidth="md">
+      <Typography style={{ marginTop: '30px', color: 'black', marginBottom: '10%' }} variant="h6">
+        貴方の日記
+      </Typography>
+      <FetchMyDiaries />
+    </Container>
+  );
+};
+
+export default MyProfile;

--- a/React/unknwon-react-diary/src/component/MyProfile.js
+++ b/React/unknwon-react-diary/src/component/MyProfile.js
@@ -1,17 +1,53 @@
-import React from 'react';
+import React, { useEffect, useState } from 'react';
+import { Auth, API } from 'aws-amplify';
 import FetchMyDiaries from './FetchMyDiaries';
 import StatisticalDataCard from './StatisticalDataCard';
 import Container from '@material-ui/core/Container';
 import Typography from '@material-ui/core/Typography';
 
 const MyProfile = () => {
+  const [myDiaries, setMyDiaries] = useState([]);
+
+  useEffect(() => {
+    const envAPI = () => {
+      const env = process.env.REACT_APP_ENVIROMENT;
+      console.log(env);
+      if (env === 'prod') {
+        return 'GETMyDiariesAPIProd';
+      } else if (env === 'dev') {
+        return 'GETMyDiariesAPIDev';
+      }
+    };
+
+    const fetchMyDiaries = async () => {
+      const apiName = envAPI();
+      const path = '';
+
+      const myInit = {
+        headers: {
+          Authorization: `Bearer ${(await Auth.currentSession()).getIdToken().getJwtToken()}`,
+        },
+      };
+
+      await API.get(apiName, path, myInit)
+        .then((response) => {
+          console.log(response.Diaries);
+          setMyDiaries(response.Diaries);
+        })
+        .catch((err) => {
+          console.log(err);
+        });
+    };
+
+    fetchMyDiaries();
+  }, []);
   return (
     <Container style={{ marginTop: '40px' }} maxWidth="md">
       <Typography style={{ marginTop: '30px', color: 'black', marginBottom: '10%' }} variant="h6">
         貴方のプロフィール
       </Typography>
-      <StatisticalDataCard />
-      <FetchMyDiaries />
+      <StatisticalDataCard myDiaries={myDiaries} />
+      <FetchMyDiaries myDiaries={myDiaries} />
     </Container>
   );
 };

--- a/React/unknwon-react-diary/src/component/MyProfile.js
+++ b/React/unknwon-react-diary/src/component/MyProfile.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import FetchMyDiaries from './FetchMyDiaries';
+import StatisticalDataCard from './StatisticalDataCard';
 import Container from '@material-ui/core/Container';
 import Typography from '@material-ui/core/Typography';
 
@@ -7,8 +8,9 @@ const MyProfile = () => {
   return (
     <Container style={{ marginTop: '40px' }} maxWidth="md">
       <Typography style={{ marginTop: '30px', color: 'black', marginBottom: '10%' }} variant="h6">
-        貴方の日記
+        貴方のプロフィール
       </Typography>
+      <StatisticalDataCard />
       <FetchMyDiaries />
     </Container>
   );

--- a/React/unknwon-react-diary/src/component/StatisticalDataCard.js
+++ b/React/unknwon-react-diary/src/component/StatisticalDataCard.js
@@ -29,14 +29,20 @@ const useStyles = makeStyles((theme) => ({
   numOfGotLike: { flex: 1 },
 }));
 
-const StatisticalDataCard = () => {
+const StatisticalDataCard = (props) => {
   const classes = useStyles();
+
+  const numberOfMyDiaries = props.myDiaries.length;
+  var numberOfMydieriesReaction = 0;
+  props.myDiaries.forEach((diary, index) => {
+    numberOfMydieriesReaction += Number(diary.reaction);
+  });
   return (
     <Grid container className={classes.grid}>
       <Card className={classes.card}>
         <div className={classes.numOfPost}>
           <CardContent className={classes.number}>
-            <Typography variant="h6">15</Typography>
+            <Typography variant="h6">{numberOfMyDiaries}</Typography>
             <Typography component="h5" variant="h5">
               YourPost
             </Typography>
@@ -44,7 +50,7 @@ const StatisticalDataCard = () => {
         </div>
         <div className={classes.numOfGotLike}>
           <CardContent className={classes.number}>
-            <Typography variant="h6">24</Typography>
+            <Typography variant="h6">{numberOfMydieriesReaction}</Typography>
             <Typography component="h5" variant="h5">
               Like
             </Typography>

--- a/React/unknwon-react-diary/src/component/StatisticalDataCard.js
+++ b/React/unknwon-react-diary/src/component/StatisticalDataCard.js
@@ -1,0 +1,58 @@
+import React from 'react';
+import { makeStyles } from '@material-ui/core/styles';
+import Grid from '@material-ui/core/Grid';
+import Card from '@material-ui/core/Card';
+import CardContent from '@material-ui/core/CardContent';
+import Typography from '@material-ui/core/Typography';
+
+const useStyles = makeStyles((theme) => ({
+  grid: {
+    display: 'flex',
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
+  card: {
+    maxWidth: 345,
+    height: '100%',
+    width: '100%',
+    display: 'flex',
+    marginBottom: '4%',
+    border: 'thick double black',
+  },
+  cardContent: {
+    display: 'flex',
+    justifyContent: 'center',
+    alignItems: 'center',
+    flexGrow: 1,
+  },
+  numOfPost: { flex: 1 },
+  numOfGotLike: { flex: 1 },
+}));
+
+const StatisticalDataCard = () => {
+  const classes = useStyles();
+  return (
+    <Grid container className={classes.grid}>
+      <Card className={classes.card}>
+        <div className={classes.numOfPost}>
+          <CardContent className={classes.number}>
+            <Typography variant="h6">15</Typography>
+            <Typography component="h5" variant="h5">
+              YourPost
+            </Typography>
+          </CardContent>
+        </div>
+        <div className={classes.numOfGotLike}>
+          <CardContent className={classes.number}>
+            <Typography variant="h6">24</Typography>
+            <Typography component="h5" variant="h5">
+              Like
+            </Typography>
+          </CardContent>
+        </div>
+      </Card>
+    </Grid>
+  );
+};
+
+export default StatisticalDataCard;


### PR DESCRIPTION
# 目的
- プロフィールページに自分が投稿した日記のデータを数値としてカードで表示したい

# やったこと
- 自分の日記一覧ページをプロフィールページへ変更
- 自分がポストした日記の数ともらったいいねの数を集計してカードに表示

# 特記事項
- デザインは要検討