### PR TITLE
日記のタイトルと日付を表示できるように

### DIFF
--- a/React/unknwon-react-diary/src/component/FetchDiary.js
+++ b/React/unknwon-react-diary/src/component/FetchDiary.js
@@ -80,9 +80,20 @@ const DiaryFetch = () => {
 
   return (
     <Container style={{ marginTop: '40px' }} maxWidth="md">
-      <Typography style={{ marginTop: '30px', color: 'black', marginBottom: '10%' }} variant="h6">
-        誰かのある日
-      </Typography>
+      {diary.content ? (
+        <Grid container justifyContent="space-around" style={{ marginTop: '8%', marginBottom: '5%' }}>
+          <Typography variant="h5" component="h2" style={{ marginBottom: '2%' }}>
+            {diary.title !== '' ? diary.title : 'タイトル'}
+          </Typography>
+          <Typography variant="subtitle1" component="h2">
+            {diary.date ? diary.date : '日付'}
+          </Typography>
+        </Grid>
+      ) : (
+        <Typography style={{ marginTop: '30px', color: 'black', marginBottom: '5%' }} variant="h6">
+          誰かのある日
+        </Typography>
+      )}
 
       <TextField style={{ width: '100%', marginBottom: '5%' }} multiline rows={20} value={diary.content} disabled />
       <Grid container justify="flex-end">

--- a/React/unknwon-react-diary/src/component/FetchDiary.js
+++ b/React/unknwon-react-diary/src/component/FetchDiary.js
@@ -70,6 +70,7 @@ const DiaryFetch = () => {
     await API.post(apiName, path, myInit)
       .then((response) => {
         console.log('成功');
+        console.log(diary);
         setDiary({ ...diary, reaction: response.reaction });
       })
       .catch((err) => {
@@ -83,13 +84,7 @@ const DiaryFetch = () => {
         誰かのある日
       </Typography>
 
-      <TextField
-        style={{ width: '100%', marginBottom: '5%' }}
-        multiline
-        rows={20}
-        value={diary.diary_content}
-        disabled
-      />
+      <TextField style={{ width: '100%', marginBottom: '5%' }} multiline rows={20} value={diary.content} disabled />
       <Grid container justify="flex-end">
         <Button style={{ marginRight: '3%' }} variant="contained" color="primary" onClick={() => fetchDiary()}>
           <MenuBookIcon style={{ marginRight: '1%', color: 'white' }} />

--- a/React/unknwon-react-diary/src/component/MyDiaryDetail.js
+++ b/React/unknwon-react-diary/src/component/MyDiaryDetail.js
@@ -11,9 +11,14 @@ const MyDiaryDetail = () => {
   const { myDiaryDetail } = useContext(ApiContext);
   return (
     <Container style={{ marginTop: '20px' }} maxWidth="md">
-      <Typography style={{ marginTop: '30px', color: 'black', marginBottom: '10%' }} variant="h6">
-        貴方の日記の詳細
-      </Typography>
+      <Grid container justifyContent="space-around" style={{ marginTop: '8%', marginBottom: '5%' }}>
+        <Typography variant="h5" component="h2" style={{ marginBottom: '2%' }}>
+          {myDiaryDetail.diaryTitle !== '' ? myDiaryDetail.diaryTitle : 'タイトル'}
+        </Typography>
+        <Typography variant="subtitle1" component="h2">
+          {myDiaryDetail.diaryDate ? myDiaryDetail.diaryDate : '日付'}
+        </Typography>
+      </Grid>
       <TextField
         style={{ width: '100%', marginBottom: '5%' }}
         multiline

--- a/React/unknwon-react-diary/src/component/PostDiary.js
+++ b/React/unknwon-react-diary/src/component/PostDiary.js
@@ -142,9 +142,7 @@ const DiaryPost = () => {
           variant="contained"
           color="primary"
           onClick={() => survayPost()}
-          disabled={Boolean(
-            !(17 <= postDiary.length && postDiary.length < 5000 && 3 <= postDiaryTitle.length && postDiaryTitle.length)
-          )}
+          disabled={Boolean(!(17 <= postDiary.length && postDiary.length < 5000 && postDiaryTitle.length <= 30))}
         >
           <CreateIcon style={{ color: 'white' }} />
         </Button>

--- a/backend/comconfirm-lambda/functions/diary-getter/domain/get-diary.go
+++ b/backend/comconfirm-lambda/functions/diary-getter/domain/get-diary.go
@@ -3,7 +3,6 @@ package domain
 import (
 	"encoding/json"
 	"fmt"
-	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/dynamodb"
@@ -15,12 +14,12 @@ import (
 
 // Diary - 日記の内容を表現する構造体です
 type Diary struct {
-	ID       string     // id
-	PostAt   string     // ポストされた日時
-	Title    string     `json:"title"`   // 日記のタイトル
-	Content  string     `json:"content"` // 日記の本文
-	Date     *time.Time `json:"date"`    // 日記の日付
-	Reaction string     // 日記のリアクション
+	ID       string  `json:"id"`      // id
+	PostAt   string  `json:"post_at"` // ポストされた日時
+	Title    string  `json:"title"`   // 日記のタイトル
+	Content  string  `json:"content"` // 日記の本文
+	Date     *string `json:"date"`    // 日記の日付
+	Reaction string  `json:"reaction"`
 }
 
 // GetDiary - 日記を表現する構造体です

--- a/backend/comconfirm-lambda/functions/diary-getter/usecase/getter-job.go
+++ b/backend/comconfirm-lambda/functions/diary-getter/usecase/getter-job.go
@@ -18,10 +18,7 @@ type GetterJob struct {
 
 // ResultDiary はAPIのresponse内に格納する日記の内容を格納する構造体です
 type ResultDiary struct {
-	ID           string `json:"id"`
-	PostAt       string `json:"post_at"`
-	DiaryContent string `json:"diary_content"`
-	Reaction     string `json:"reaction"`
+	domain.Diary
 }
 
 func (gj *GetterJob) featchDiary(ctx context.Context) (domain.Diary, error) {
@@ -66,8 +63,10 @@ func (gj *GetterJob) Run(ctx context.Context) (ResultDiary, error) {
 
 	ResultDiary.ID = getItem.ID
 	ResultDiary.PostAt = getItem.PostAt
-	ResultDiary.DiaryContent = getItem.Content
+	ResultDiary.Content = getItem.Content
 	ResultDiary.Reaction = getItem.Reaction
+	ResultDiary.Date = getItem.Date
+	ResultDiary.Title = getItem.Title
 
 	return ResultDiary, nil
 


### PR DESCRIPTION
# 目的
- 日記を取得した時にタイトルと日付を表示したい

# やったこと
- 他人の日記を取得する画面にてタイトルと日付を表示
- 自分の日記の詳細を取得する画面にてタイトルと日付を表示
- 他人の日記を取得するAPIにてタイトル項目と日付項目が取得できないようになっていたのでそちらを修正した

# 特記事項
- デザインは要検討