### PR TITLE
いいねした日記の一覧を閲覧できるように

### DIFF
--- a/React/unknwon-react-diary/src/App.js
+++ b/React/unknwon-react-diary/src/App.js
@@ -11,6 +11,7 @@ import PostDiary from './component/PostDiary';
 import FetchDiary from './component/FetchDiary';
 import MyDiaryDetail from './component/MyDiaryDetail';
 import MyProfile from './component/MyProfile';
+import MyFavoriteDiaries from './component/MyFavoriteDiaries';
 import Home from './component/Home';
 import Footer from './component/Footer';
 import { Route, BrowserRouter } from 'react-router-dom';
@@ -59,6 +60,7 @@ function App() {
                 <Route exact path="/diary" component={FetchDiary} />
                 <Route exact path="/post" component={PostDiary} />
                 <Route exact path="/" component={Home} />
+                <Route exact path="/favorites" component={MyFavoriteDiaries} />
                 <Footer />
               </div>
             ) : (

--- a/React/unknwon-react-diary/src/App.js
+++ b/React/unknwon-react-diary/src/App.js
@@ -11,7 +11,7 @@ import PostDiary from './component/PostDiary';
 import FetchDiary from './component/FetchDiary';
 import MyDiaryDetail from './component/MyDiaryDetail';
 import MyProfile from './component/MyProfile';
-import MyFavoriteDiaries from './component/MyFavoriteDiaries';
+import MyFavoritesDiaries from './component/MyFavoritesDiaries';
 import Home from './component/Home';
 import Footer from './component/Footer';
 import { Route, BrowserRouter } from 'react-router-dom';
@@ -60,7 +60,7 @@ function App() {
                 <Route exact path="/diary" component={FetchDiary} />
                 <Route exact path="/post" component={PostDiary} />
                 <Route exact path="/" component={Home} />
-                <Route exact path="/favorites" component={MyFavoriteDiaries} />
+                <Route exact path="/favorites" component={MyFavoritesDiaries} />
                 <Footer />
               </div>
             ) : (

--- a/React/unknwon-react-diary/src/component/FetchDiary.js
+++ b/React/unknwon-react-diary/src/component/FetchDiary.js
@@ -1,4 +1,5 @@
 import React, { useState, useEffect } from 'react';
+import { useLocation } from 'react-router-dom';
 import { Auth, API } from 'aws-amplify';
 import { Grid } from '@material-ui/core';
 import Container from '@material-ui/core/Container';
@@ -11,6 +12,7 @@ import TextField from '@material-ui/core/TextField';
 import AddCommentIcon from '@material-ui/icons/AddComment';
 
 const DiaryFetch = () => {
+  const location = useLocation();
   const [diary, setDiary] = useState({});
   const [dialogOpen, setDialogOpen] = useState(false);
   const [isEditComment, setIsEditComment] = useState(false);
@@ -67,7 +69,7 @@ const DiaryFetch = () => {
   useEffect(() => {
     const fetchDiary = async () => {
       const apiName = envFetchAPI();
-      const path = '';
+      const path = `${location.search}`;
 
       const myInit = {
         headers: {
@@ -88,11 +90,11 @@ const DiaryFetch = () => {
         });
     };
     fetchDiary();
-  }, []);
+  }, [location.search]);
 
   const fetchDiary = async () => {
     const apiName = envFetchAPI();
-    const path = '';
+    const path = ``;
 
     const myInit = {
       headers: {
@@ -188,13 +190,23 @@ const DiaryFetch = () => {
           <p style={{ margin: 0, fontWeight: 'bold', fontSize: '16px' }}>{diary.reaction}</p>
         </div>
       </div>
-      <Grid container justify="flex-end">
-        <Button style={{ marginRight: '3%' }} variant="contained" color="primary" onClick={() => fetchDiary()}>
-          <p style={{ color: 'white', margin: '3px', fontWeight: 'bold' }}>日記を取得する</p>
-        </Button>
-      </Grid>
+      {location.search ? (
+        <></>
+      ) : (
+        <Grid container justify="flex-end">
+          <Button style={{ marginRight: '3%' }} variant="contained" color="primary" onClick={() => fetchDiary()}>
+            <p style={{ color: 'white', margin: '3px', fontWeight: 'bold' }}>日記を取得する</p>
+          </Button>
+        </Grid>
+      )}
+
       <div className="flex flex-col w-9/12 pl-8 mt-4">
-        <p className="text-xl text-gray-800 font-semibold mb-3 text-left">足跡を残す</p>
+        {location.search ? (
+          <p className="text-xl text-gray-800 font-semibold mb-3 text-left">足跡</p>
+        ) : (
+          <p className="text-xl text-gray-800 font-semibold mb-3 text-left">足跡を残す</p>
+        )}
+
         {diary.comments ? (
           diary.comments.map((comment) => (
             <div className="bg-white shadow-xl rounded-2xl mb-2 sm:w-9/12 md:w-1/2 text-left">

--- a/React/unknwon-react-diary/src/component/MyFavoriteDiaries.js
+++ b/React/unknwon-react-diary/src/component/MyFavoriteDiaries.js
@@ -1,0 +1,147 @@
+import React, { useState, useEffect } from 'react';
+import { Auth, API } from 'aws-amplify';
+import Typography from '@material-ui/core/Typography';
+import { Link } from 'react-router-dom';
+import FavoriteIcon from '@material-ui/icons/Favorite';
+import Button from '@material-ui/core/Button';
+
+const FetchMyFavoriteDiaries = (props) => {
+  const [page, setPage] = useState(1);
+  const [myFavoriteDiaries, setMyFavoriteDiaries] = useState([]);
+
+  const sliceByNumber = (array, number) => {
+    const length = Math.ceil(array.length / number);
+    return new Array(length).fill().map((_, i) => array.slice(i * number, (i + 1) * number));
+  };
+
+  const lastDiraryIDList = sliceByNumber(myFavoriteDiaries, 6);
+
+  let maxPageNumber = Math.ceil(myFavoriteDiaries.length / 6);
+
+  const envAPI = () => {
+    const env = process.env.REACT_APP_ENVIROMENT;
+    console.log(env);
+    if (env === 'prod') {
+      return 'GETMyDiariesAPIProd';
+    } else if (env === 'dev') {
+      return 'GETMyDiariesAPIDev';
+    }
+  };
+
+  useEffect(() => {
+    const fetchMyFavoriteDiaries = async () => {
+      const limit = '6';
+      const apiName = envAPI();
+      const path = `?limit=${limit}`;
+
+      const myInit = {
+        headers: {
+          Authorization: `Bearer ${(await Auth.currentSession()).getIdToken().getJwtToken()}`,
+        },
+      };
+
+      await API.get(apiName, path, myInit)
+        .then((response) => {
+          setMyFavoriteDiaries(response.Diaries);
+          setPage(1);
+        })
+        .catch((err) => {
+          console.log(err);
+        });
+    };
+    fetchMyFavoriteDiaries('');
+  }, []);
+
+  const fetchMyFavoriteDiaries = async (id) => {
+    const limit = '6';
+    const apiName = envAPI();
+    const path = `?id=${id}&limit=${limit}`;
+
+    const myInit = {
+      headers: {
+        Authorization: `Bearer ${(await Auth.currentSession()).getIdToken().getJwtToken()}`,
+      },
+    };
+
+    await API.get(apiName, path, myInit)
+      .then((response) => {
+        setMyFavoriteDiaries(response.Diaries);
+      })
+      .catch((err) => {
+        console.log(err);
+      });
+  };
+
+  const prevPage = () => {
+    if (page === 2) {
+      fetchMyFavoriteDiaries('');
+    } else {
+      fetchMyFavoriteDiaries(lastDiraryIDList[page - 3].slice(-1)[0].id);
+    }
+    setPage(page - 1);
+  };
+
+  const nextPage = () => {
+    fetchMyFavoriteDiaries(lastDiraryIDList[page - 1].slice(-1)[0].id);
+    setPage(page + 1);
+  };
+  return (
+    <>
+      <Typography style={{ marginTop: '30px', color: 'black' }} variant="h6">
+        いいねした日記
+      </Typography>
+      <div className="flex flex-wrap content-between justify-center">
+        {myFavoriteDiaries.map((value, key) => {
+          const diaryContent = value.content;
+          const diaryReaction = value.reaction;
+          const diaryTitle = value.title ? value.title : 'タイトルなし';
+          const diaryDate = value.date ? value.date : '日付なし';
+          const maxLength = 37;
+          let modifiedDiaryContent = '';
+          if (diaryContent.length > maxLength) {
+            modifiedDiaryContent = diaryContent.substr(0, maxLength) + '...';
+          } else {
+            modifiedDiaryContent = diaryContent;
+          }
+
+          return (
+            <div key={key} className="shadow-xl rounded-md bg-white w-80 m-6">
+              <Link to={{ pathname: '/mydiary-detail', search: `?id=${value.id}` }} style={{ textDecoration: 'none' }}>
+                <div className="flex flex-col h-full content-between">
+                  <div className="p-4 mb-auto">
+                    <p className="text-left text-xl font-semibold text-gray-600">{diaryTitle}</p>
+                    <Typography style={{ textAlign: 'left' }} variant="body2" color="textSecondary" component="p">
+                      {modifiedDiaryContent}
+                    </Typography>
+                  </div>
+                  <div className="flex px-2 pb-2 items-center">
+                    <FavoriteIcon style={{ marginRight: '2%' }} color="error" />
+                    <p style={{ margin: 0, fontWeight: 'bold', fontSize: '16px' }}>{diaryReaction}</p>
+                    <p className="text-gray-500 text-lg ml-auto">{diaryDate}</p>
+                  </div>
+                </div>
+              </Link>
+            </div>
+          );
+        })}
+      </div>
+
+      <div style={{ paddingLeft: '12px', paddingRight: '12px', marginTop: '36px', marginBottom: '48px' }}>
+        {page !== 1 && (
+          <Button style={{ marginRight: '3%' }} onClick={() => prevPage()}>
+            <a href={() => false}>&lt; Previous</a>
+          </Button>
+        )}
+        {page !== maxPageNumber && (
+          <Button onClick={() => nextPage()}>
+            <a href={() => false} className="ml-4">
+              Next &gt;
+            </a>
+          </Button>
+        )}
+      </div>
+    </>
+  );
+};
+
+export default FetchMyFavoriteDiaries;

--- a/React/unknwon-react-diary/src/component/MyFavoritesDiaries.js
+++ b/React/unknwon-react-diary/src/component/MyFavoritesDiaries.js
@@ -8,6 +8,7 @@ import Container from '@material-ui/core/Container';
 
 const FetchMyFavoritesDiaries = () => {
   const [page, setPage] = useState(1);
+  const [myAllFavoritesDiaries, setMyAllFavoritesDiaries] = useState([]);
   const [myFavoritesDiaries, setMyFavoritesDiaries] = useState([]);
 
   const sliceByNumber = (array, number) => {
@@ -15,9 +16,9 @@ const FetchMyFavoritesDiaries = () => {
     return new Array(length).fill().map((_, i) => array.slice(i * number, (i + 1) * number));
   };
 
-  const lastDiraryIDList = sliceByNumber(myFavoritesDiaries, 6);
+  const lastDiraryIDList = sliceByNumber(myAllFavoritesDiaries, 6);
 
-  let maxPageNumber = Math.ceil(myFavoritesDiaries.length / 6);
+  let maxPageNumber = Math.ceil(myAllFavoritesDiaries.length / 6);
 
   const envAPI = () => {
     const env = process.env.REACT_APP_ENVIROMENT;
@@ -25,15 +26,14 @@ const FetchMyFavoritesDiaries = () => {
     if (env === 'prod') {
       return 'GETMyDiariesAPIProd';
     } else if (env === 'dev') {
-      return 'GETMyDiariesAPIDev';
+      return 'FAVORITESDiaryAPIDev';
     }
   };
 
   useEffect(() => {
     const fetchMyFavoritesDiaries = async () => {
-      const limit = '6';
       const apiName = envAPI();
-      const path = `?limit=${limit}`;
+      const path = ``;
 
       const myInit = {
         headers: {
@@ -43,7 +43,8 @@ const FetchMyFavoritesDiaries = () => {
 
       await API.get(apiName, path, myInit)
         .then((response) => {
-          setMyFavoritesDiaries(response.Diaries);
+          setMyAllFavoritesDiaries(response.Diaries);
+          setMyFavoritesDiaries(response.Diaries.slice(0, 6));
           setPage(1);
         })
         .catch((err) => {
@@ -107,7 +108,7 @@ const FetchMyFavoritesDiaries = () => {
 
           return (
             <div key={key} className="shadow-xl rounded-md bg-white w-80 m-6">
-              <Link to={{ pathname: '/mydiary-detail', search: `?id=${value.id}` }} style={{ textDecoration: 'none' }}>
+              <Link to={{ pathname: '/diary', search: `?id=${value.id}` }} style={{ textDecoration: 'none' }}>
                 <div className="flex flex-col h-full content-between">
                   <div className="p-4 mb-auto">
                     <p className="text-left text-xl font-semibold text-gray-600">{diaryTitle}</p>

--- a/React/unknwon-react-diary/src/component/MyFavoritesDiaries.js
+++ b/React/unknwon-react-diary/src/component/MyFavoritesDiaries.js
@@ -4,19 +4,20 @@ import Typography from '@material-ui/core/Typography';
 import { Link } from 'react-router-dom';
 import FavoriteIcon from '@material-ui/icons/Favorite';
 import Button from '@material-ui/core/Button';
+import Container from '@material-ui/core/Container';
 
-const FetchMyFavoriteDiaries = (props) => {
+const FetchMyFavoritesDiaries = () => {
   const [page, setPage] = useState(1);
-  const [myFavoriteDiaries, setMyFavoriteDiaries] = useState([]);
+  const [myFavoritesDiaries, setMyFavoritesDiaries] = useState([]);
 
   const sliceByNumber = (array, number) => {
     const length = Math.ceil(array.length / number);
     return new Array(length).fill().map((_, i) => array.slice(i * number, (i + 1) * number));
   };
 
-  const lastDiraryIDList = sliceByNumber(myFavoriteDiaries, 6);
+  const lastDiraryIDList = sliceByNumber(myFavoritesDiaries, 6);
 
-  let maxPageNumber = Math.ceil(myFavoriteDiaries.length / 6);
+  let maxPageNumber = Math.ceil(myFavoritesDiaries.length / 6);
 
   const envAPI = () => {
     const env = process.env.REACT_APP_ENVIROMENT;
@@ -29,7 +30,7 @@ const FetchMyFavoriteDiaries = (props) => {
   };
 
   useEffect(() => {
-    const fetchMyFavoriteDiaries = async () => {
+    const fetchMyFavoritesDiaries = async () => {
       const limit = '6';
       const apiName = envAPI();
       const path = `?limit=${limit}`;
@@ -42,17 +43,17 @@ const FetchMyFavoriteDiaries = (props) => {
 
       await API.get(apiName, path, myInit)
         .then((response) => {
-          setMyFavoriteDiaries(response.Diaries);
+          setMyFavoritesDiaries(response.Diaries);
           setPage(1);
         })
         .catch((err) => {
           console.log(err);
         });
     };
-    fetchMyFavoriteDiaries('');
+    fetchMyFavoritesDiaries('');
   }, []);
 
-  const fetchMyFavoriteDiaries = async (id) => {
+  const fetchMyFavoritesDiaries = async (id) => {
     const limit = '6';
     const apiName = envAPI();
     const path = `?id=${id}&limit=${limit}`;
@@ -65,7 +66,7 @@ const FetchMyFavoriteDiaries = (props) => {
 
     await API.get(apiName, path, myInit)
       .then((response) => {
-        setMyFavoriteDiaries(response.Diaries);
+        setMyFavoritesDiaries(response.Diaries);
       })
       .catch((err) => {
         console.log(err);
@@ -74,24 +75,24 @@ const FetchMyFavoriteDiaries = (props) => {
 
   const prevPage = () => {
     if (page === 2) {
-      fetchMyFavoriteDiaries('');
+      fetchMyFavoritesDiaries('');
     } else {
-      fetchMyFavoriteDiaries(lastDiraryIDList[page - 3].slice(-1)[0].id);
+      fetchMyFavoritesDiaries(lastDiraryIDList[page - 3].slice(-1)[0].id);
     }
     setPage(page - 1);
   };
 
   const nextPage = () => {
-    fetchMyFavoriteDiaries(lastDiraryIDList[page - 1].slice(-1)[0].id);
+    fetchMyFavoritesDiaries(lastDiraryIDList[page - 1].slice(-1)[0].id);
     setPage(page + 1);
   };
   return (
-    <>
+    <Container style={{ marginTop: '40px' }} maxWidth="md">
       <Typography style={{ marginTop: '30px', color: 'black' }} variant="h6">
         いいねした日記
       </Typography>
       <div className="flex flex-wrap content-between justify-center">
-        {myFavoriteDiaries.map((value, key) => {
+        {myFavoritesDiaries.map((value, key) => {
           const diaryContent = value.content;
           const diaryReaction = value.reaction;
           const diaryTitle = value.title ? value.title : 'タイトルなし';
@@ -140,8 +141,8 @@ const FetchMyFavoriteDiaries = (props) => {
           </Button>
         )}
       </div>
-    </>
+    </Container>
   );
 };
 
-export default FetchMyFavoriteDiaries;
+export default FetchMyFavoritesDiaries;

--- a/React/unknwon-react-diary/src/component/Navbar.js
+++ b/React/unknwon-react-diary/src/component/Navbar.js
@@ -9,6 +9,7 @@ import CreateIcon from '@material-ui/icons/Create';
 import MenuBookIcon from '@material-ui/icons/MenuBook';
 import AccountBoxIcon from '@material-ui/icons/AccountBox';
 import ExitToAppIcon from '@material-ui/icons/ExitToApp';
+import FavoriteIcon from '@material-ui/icons/Favorite';
 
 const useStyles = makeStyles((theme) => ({
   title: {
@@ -22,7 +23,7 @@ const useStyles = makeStyles((theme) => ({
     textDecoration: 'none',
     color: 'hsla(0,0%,100%,.8)',
     display: 'flex',
-    marginRight: '16px',
+    marginRight: '8px',
   },
   icon: {
     marginRight: '2px',
@@ -63,7 +64,7 @@ const Navbar = () => {
 
   return (
     <AppBar position="static" className="mb-10">
-      <Toolbar className="sm:max-w-full md:w-9/12 lg:w-8/12 xl:w-1/2" style={{ margin: '0 auto' }}>
+      <Toolbar className="sm:max-w-full md:w-10/12 lg:w-8/12 xl:w-1/2" style={{ margin: '0 auto' }}>
         <Link to="/" className={classes.title}>
           <Typography variant="h5" className={classes.title}>
             Unknown Diary
@@ -79,6 +80,10 @@ const Navbar = () => {
               <MenuBookIcon className={classes.icon} style={{ top: '-1px' }} />
               <p className={classes.iconText}>誰かのあの日</p>
             </Link>
+            <Link to="/diary" className={classes.iconLink}>
+              <FavoriteIcon className={classes.icon} />
+              <p className={classes.iconText}>いいねした日記</p>
+            </Link>
             <Link to="/mydiary" className={classes.iconLink} style={{ marginRight: '4px', marginLeft: '8px' }}>
               <AccountBoxIcon />
             </Link>
@@ -91,6 +96,9 @@ const Navbar = () => {
             </Link>
             <Link to="/diary" className={classes.iconLinkSm}>
               <MenuBookIcon />
+            </Link>
+            <Link to="/diary" className={classes.iconLinkSm}>
+              <FavoriteIcon />
             </Link>
             <Link to="/mydiary" className={classes.iconLinkSm}>
               <AccountBoxIcon />

--- a/React/unknwon-react-diary/src/component/Navbar.js
+++ b/React/unknwon-react-diary/src/component/Navbar.js
@@ -80,7 +80,7 @@ const Navbar = () => {
               <MenuBookIcon className={classes.icon} style={{ top: '-1px' }} />
               <p className={classes.iconText}>誰かのあの日</p>
             </Link>
-            <Link to="/diary" className={classes.iconLink}>
+            <Link to="/favorites" className={classes.iconLink}>
               <FavoriteIcon className={classes.icon} />
               <p className={classes.iconText}>いいねした日記</p>
             </Link>
@@ -97,7 +97,7 @@ const Navbar = () => {
             <Link to="/diary" className={classes.iconLinkSm}>
               <MenuBookIcon />
             </Link>
-            <Link to="/diary" className={classes.iconLinkSm}>
+            <Link to="/favorites" className={classes.iconLinkSm}>
               <FavoriteIcon />
             </Link>
             <Link to="/mydiary" className={classes.iconLinkSm}>

--- a/React/unknwon-react-diary/src/index.js
+++ b/React/unknwon-react-diary/src/index.js
@@ -49,6 +49,11 @@ Amplify.configure({
         region: region,
       },
       {
+        name: 'FAVORITESDiaryAPIDev',
+        endpoint: process.env.REACT_APP_DEV_API_ENDPOINT + 'get/favorites',
+        region: region,
+      },
+      {
         name: 'POSTStoreAPIProd',
         endpoint: process.env.REACT_APP_PROD_API_ENDPOINT + 'post',
         region: region,

--- a/backend/comconfirm-lambda/Makefile
+++ b/backend/comconfirm-lambda/Makefile
@@ -7,7 +7,7 @@ GO_LDFLAGS  = -ldflags="-s -w"
 GOOS        = linux
 
 ### ターゲットパラメーター
-TARGETS = bin/receiver bin/getter bin/getter-my-diaries bin/reaction-diary bin/update-diary bin/comment-diary
+TARGETS = bin/receiver bin/getter bin/getter-my-diaries bin/reaction-diary bin/update-diary bin/comment-diary bin/getter-my-favorites-diaries
 
 ### 環境 dev or prod prodの場合は 手動で指定
 STAGE=dev
@@ -40,4 +40,7 @@ bin/update-diary: functions/diary-update/main.go
 	GOOS=$(GOOS) $(GO_BUILD) $(GO_LDFLAGS) -o $@ $<
 
 bin/comment-diary: functions/diary-comment/main.go
+	GOOS=$(GOOS) $(GO_BUILD) $(GO_LDFLAGS) -o $@ $<
+
+bin/getter-my-favorites-diaries: functions/diary-my-favorites-getter/main.go
 	GOOS=$(GOOS) $(GO_BUILD) $(GO_LDFLAGS) -o $@ $<

--- a/backend/comconfirm-lambda/functions/diary-my-favorites-getter/adapter/adapter.go
+++ b/backend/comconfirm-lambda/functions/diary-my-favorites-getter/adapter/adapter.go
@@ -1,0 +1,14 @@
+package adapter
+
+import (
+	"github.com/aws/aws-sdk-go/service/dynamodb"
+	"github.com/aws/aws-sdk-go/service/dynamodb/expression"
+)
+
+// DynamoDBClientRepository - DynamoDBを操作するためのインタフェース
+// infraから使用するメソッドを列挙
+type DynamoDBClientRepository interface {
+	GetAllRecords(expr *expression.Expression, exclusiveStartKey map[string]*dynamodb.AttributeValue) (*dynamodb.ScanOutput, error)
+	GetAllRecordsWithLimit(expr *expression.Expression, exclusiveStartKey map[string]*dynamodb.AttributeValue, limit *int64) (*dynamodb.ScanOutput, error)
+	QueryByExpressionNoindex(expr *expression.Expression) (*dynamodb.QueryOutput, error)
+}

--- a/backend/comconfirm-lambda/functions/diary-my-favorites-getter/controller/get-my-favorites-diary-controller.go
+++ b/backend/comconfirm-lambda/functions/diary-my-favorites-getter/controller/get-my-favorites-diary-controller.go
@@ -1,0 +1,29 @@
+package controller
+
+import (
+	"context"
+
+	"github.com/aws/aws-lambda-go/events"
+	"github.com/s-amano/unknown-diary/backend/comconfirm-lambda/functions/diary-my-favorites-getter/adapter"
+	"github.com/s-amano/unknown-diary/backend/comconfirm-lambda/functions/diary-my-favorites-getter/usecase"
+)
+
+// GetterController は コントローラーを表現する構造体です
+type GetterController struct {
+	DynamoDBClientRepo adapter.DynamoDBClientRepository
+	DiaryGetter        string
+}
+
+// Run - usecase 上の GetterJob 経由で処理する
+func (c *GetterController) Run(ctx context.Context, apiGWEvent events.APIGatewayProxyRequest) (usecase.ResultDiaries, error) {
+	gj := usecase.GetterJob{
+		DynamoDBClientRepo: c.DynamoDBClientRepo,
+		DiaryGetter:        c.DiaryGetter,
+	}
+
+	items, err := gj.Run(ctx, apiGWEvent)
+	if err != nil {
+		return items, err
+	}
+	return items, nil
+}

--- a/backend/comconfirm-lambda/functions/diary-my-favorites-getter/domain/get-my-favorites-diary.go
+++ b/backend/comconfirm-lambda/functions/diary-my-favorites-getter/domain/get-my-favorites-diary.go
@@ -1,0 +1,181 @@
+package domain
+
+import (
+	"encoding/json"
+	"fmt"
+	"strconv"
+
+	"github.com/aws/aws-lambda-go/events"
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/dynamodb"
+	"github.com/aws/aws-sdk-go/service/dynamodb/expression"
+	"github.com/s-amano/unknown-diary/backend/comconfirm-lambda/functions/diary-my-favorites-getter/adapter"
+)
+
+// Diary - 各日記の内容を格納する構造体
+type Diary struct {
+	ID       string  `json:"id"`      // id
+	PostAt   string  `json:"post_at"` // ポストされた日時
+	Title    string  `json:"title"`   // 日記のタイトル
+	Content  string  `json:"content"` // 日記の本文
+	Date     *string `json:"date"`    // 日記の日付
+	Reaction string  `json:"reaction"`
+}
+
+// GetDiaries - 日記を格納する構造体
+type GetDiaries struct {
+	DiariesGetter string
+	Diaries       []Diary
+}
+
+// SetPaginationData - ページネーションに必要なデータを取得する
+func SetPaginationData(request events.APIGatewayProxyRequest, dc adapter.DynamoDBClientRepository) (map[string]*dynamodb.AttributeValue, *string, error) {
+	var err error
+
+	id := request.QueryStringParameters["id"]
+	fmt.Printf("string request Query id: %v, type:%T\n", id, id)
+
+	limit := request.QueryStringParameters["limit"]
+	fmt.Printf("string request Query id: %v, type:%T\n", limit, limit)
+	if id == "" {
+		return nil, &limit, err
+	}
+	// キー条件の生成
+	keyCond := expression.Key("id").Equal(expression.Value(id))
+	// クエリ用 expression の生成
+	expr, err := expression.NewBuilder().WithKeyCondition(keyCond).Build()
+	if err != nil {
+		fmt.Printf("exp create err %v\n", err)
+		return nil, &limit, err
+	}
+	res, err := dc.QueryByExpressionNoindex(&expr)
+	if err != nil {
+		return nil, &limit, err
+	}
+
+	item := res.Items[0]
+
+	return item, &limit, err
+}
+
+// FetchAllMyFavoritesDiaryFromDynamoDB - DynamoDB から該当するレコードを全て取得する
+func (gd *GetDiaries) FetchAllMyFavoritesDiaryFromDynamoDB(dc adapter.DynamoDBClientRepository) (*dynamodb.QueryOutput, error) {
+	// DynamoDB クエリ作成
+	filter := expression.Name("reactioners").Contains(gd.DiariesGetter)
+
+	expr, err := expression.NewBuilder().WithFilter(filter).Build()
+	if err != nil {
+		return nil, err
+	}
+
+	var exclusiveStartKey map[string]*dynamodb.AttributeValue = nil
+	defaultCount := int64(0)
+	var defaultItems []map[string]*dynamodb.AttributeValue
+	var res = &dynamodb.QueryOutput{Count: &defaultCount, Items: defaultItems}
+
+	// LastEvaluatedKeyがある間,データを取得し続ける
+	for {
+		result, err := dc.GetAllRecords(&expr, exclusiveStartKey)
+		if err != nil {
+			return nil, err
+		}
+
+		res.Items = append(res.Items, result.Items...)
+
+		*res.Count = *res.Count + *result.Count
+
+		exclusiveStartKey = result.LastEvaluatedKey
+
+		if result.LastEvaluatedKey == nil {
+			break
+		}
+
+	}
+
+	return res, nil
+}
+
+// FetchMyFavoritesDiaryFromDynamoDB - DynamoDB から該当するレコードを取得する
+func (gd *GetDiaries) FetchMyFavoritesDiaryFromDynamoDB(dc adapter.DynamoDBClientRepository, item map[string]*dynamodb.AttributeValue, limit string) (*dynamodb.QueryOutput, error) {
+	// DynamoDB クエリ作成
+	filter := expression.Name("reactioners").Contains(gd.DiariesGetter)
+
+	expr, err := expression.NewBuilder().WithFilter(filter).Build()
+	if err != nil {
+		return nil, err
+	}
+
+	var exclusiveStartKey map[string]*dynamodb.AttributeValue = nil
+
+	if item != nil {
+		exclusiveStartKey = map[string]*dynamodb.AttributeValue{
+			"id": {
+				S: aws.String(*item["id"].S),
+			},
+			"post_at": {
+				N: aws.String(*item["post_at"].N),
+			},
+			"author": {
+				S: aws.String(*item["author"].S),
+			},
+			"status_post_at": {
+				S: aws.String(*item["status_post_at"].S),
+			},
+		}
+	}
+
+	var intLimit int64
+
+	if limit != "" {
+		i, _ := strconv.Atoi(limit)
+		intLimit = int64(i)
+	}
+
+	defaultCount := int64(0)
+	var defaultItems []map[string]*dynamodb.AttributeValue
+	var res = &dynamodb.QueryOutput{Count: &defaultCount, Items: defaultItems}
+
+	result, err := dc.GetAllRecordsWithLimit(&expr, exclusiveStartKey, &intLimit)
+	if err != nil {
+		return nil, err
+	}
+
+	fmt.Printf("result %s\n", result.LastEvaluatedKey)
+
+	res.Items = append(res.Items, result.Items...)
+
+	*res.Count = *res.Count + *result.Count
+
+	return res, nil
+}
+
+// AddDiaries - DynamoDBのクエリ結果を Diaries に格納する
+func (gd *GetDiaries) AddDiaries(res *dynamodb.QueryOutput) ([]Diary, error) {
+	var err error
+
+	gd.Diaries = make([]Diary, 0, *res.Count)
+
+	for _, item := range res.Items {
+		diary := Diary{}
+
+		err = json.Unmarshal([]byte(*item["post_data"].S), &diary)
+		if err != nil {
+			fmt.Printf("failed to unmarshal post_data. input: %s", *item["post_data"])
+			continue
+		}
+		// リアクションがあるかどうかで条件分岐
+		reaction, ok := item["reaction"]
+		if !ok {
+			diary.Reaction = "0"
+		} else {
+			diary.Reaction = *reaction.S
+		}
+
+		diary.ID = *item["id"].S
+		diary.PostAt = *item["post_at"].N
+
+		gd.Diaries = append(gd.Diaries, diary)
+	}
+
+	return gd.Diaries, nil
+}

--- a/backend/comconfirm-lambda/functions/diary-my-favorites-getter/main.go
+++ b/backend/comconfirm-lambda/functions/diary-my-favorites-getter/main.go
@@ -1,0 +1,75 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+
+	"github.com/aws/aws-lambda-go/events"
+	"github.com/aws/aws-lambda-go/lambda"
+
+	"github.com/s-amano/unknown-diary/backend/comconfirm-lambda/functions/diary-my-favorites-getter/controller"
+	"github.com/s-amano/unknown-diary/infra/dynamodbclient"
+)
+
+const (
+	envNameDiaryStoreDynamoDBTable = "DIARY_STORE_DYNAMODB_TABLE"
+)
+
+var (
+	region                  string
+	dynamoDBClient          *dynamodbclient.DynamoDBClient
+	diaryStoreDynamoDBTable string
+	diaryGetter             string
+)
+
+func init() {
+	region = "ap-northeast-1"
+
+	diaryStoreDynamoDBTable = os.Getenv(envNameDiaryStoreDynamoDBTable)
+
+	// DynamoDB クライアントの初期化
+	dynamoDBClient = dynamodbclient.NewDynamoDBClient(region, diaryStoreDynamoDBTable)
+}
+
+func handler(ctx context.Context, apiGWEvent events.APIGatewayProxyRequest) (events.APIGatewayProxyResponse, error) {
+
+	// GETしたユーザー名取得
+	diaryGetter = apiGWEvent.RequestContext.Authorizer["claims"].(map[string]interface{})["cognito:username"].(string)
+
+	fmt.Printf("getter: %v\n", diaryGetter)
+
+	// コントローラの作成
+	src := controller.GetterController{
+		DynamoDBClientRepo: dynamoDBClient,
+		DiaryGetter:        diaryGetter,
+	}
+
+	items, err := src.Run(context.Background(), apiGWEvent)
+	if err != nil {
+		fmt.Printf("items作成 : %v\n", err)
+	}
+
+	j, err := json.Marshal(items)
+	if err != nil {
+		fmt.Printf("j作成 : %s\n", err)
+	}
+
+	result := events.APIGatewayProxyResponse{
+		StatusCode: 200,
+		Headers: map[string]string{
+			"Content-Type":                 "text/html",
+			"Access-Control-Allow-Headers": "Content-Type,X-Amz-Date,Authorization,X-Api-Key,X-Amz-Security-Token",
+			"Access-Control-Allow-Origin":  "*",
+			"Access-Control-Allow-Methods": "GET",
+		},
+		Body: string(j),
+	}
+	fmt.Printf("main result : %+v\n", result)
+	return result, err
+}
+
+func main() {
+	lambda.Start(handler)
+}

--- a/backend/comconfirm-lambda/functions/diary-my-favorites-getter/usecase/get-my-favorites-diary-job.go
+++ b/backend/comconfirm-lambda/functions/diary-my-favorites-getter/usecase/get-my-favorites-diary-job.go
@@ -1,0 +1,79 @@
+package usecase
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/aws/aws-lambda-go/events"
+	"github.com/aws/aws-sdk-go/service/dynamodb"
+	"github.com/s-amano/unknown-diary/backend/comconfirm-lambda/functions/diary-my-favorites-getter/adapter"
+	"github.com/s-amano/unknown-diary/backend/comconfirm-lambda/functions/diary-my-favorites-getter/domain"
+)
+
+// GetterJob は、受け取ったポストデータをを処理するジョブを表すレポジトリです
+type GetterJob struct {
+	DynamoDBClientRepo     adapter.DynamoDBClientRepository
+	DiaryGetter            string
+	DiaryLimit             string
+	DiaryExclusiveStartKey string
+
+	diaries *domain.GetDiaries
+}
+
+// ResultDiaries はAPIのresponse内に格納する日記達を格納する構造体です
+type ResultDiaries struct {
+	Diaries []domain.Diary
+}
+
+func (gj *GetterJob) featchDiaries(ctx context.Context, apiGWEvent events.APIGatewayProxyRequest) ([]domain.Diary, error) {
+	var res *dynamodb.QueryOutput
+
+	// GetDiaries を初期化
+	gj.diaries = &domain.GetDiaries{
+		DiariesGetter: gj.DiaryGetter,
+	}
+
+	// apiGWEvent のヘッダ、queryString から item を生成
+	item, limit, err := domain.SetPaginationData(apiGWEvent, gj.DynamoDBClientRepo)
+	if err != nil {
+		return []domain.Diary{}, err
+	}
+
+	// DynamoDB からデータ取得limitありなしによって分岐
+	if *limit == "" {
+		res, err = gj.diaries.FetchAllMyFavoritesDiaryFromDynamoDB(gj.DynamoDBClientRepo)
+		if err != nil {
+			fmt.Printf("fetch: %v \n", err)
+		}
+	} else {
+		res, err = gj.diaries.FetchMyFavoritesDiaryFromDynamoDB(gj.DynamoDBClientRepo, item, *limit)
+		if err != nil {
+			fmt.Printf("fetch: %v \n", err)
+		}
+	}
+
+	// DynamoDB データを Diaries に登録
+	diaries, err := gj.diaries.AddDiaries(res)
+	if err != nil {
+		return diaries, err
+	}
+	return diaries, nil
+
+}
+
+// Run は実際の処理を行うメソッドです
+func (gj *GetterJob) Run(ctx context.Context, apiGWEvent events.APIGatewayProxyRequest) (ResultDiaries, error) {
+	var err error
+
+	resultDiaries := ResultDiaries{}
+
+	getItems, err := gj.featchDiaries(ctx, apiGWEvent)
+	if err != nil {
+		fmt.Printf("getItems: %v \n", err)
+	}
+
+	resultDiaries.Diaries = getItems
+
+	return resultDiaries, nil
+
+}

--- a/backend/comconfirm-lambda/resources/getter-my-favorites-diary.yml
+++ b/backend/comconfirm-lambda/resources/getter-my-favorites-diary.yml
@@ -1,0 +1,11 @@
+getterMyFavoritesDiaries:
+  handler: bin/getter-my-favorites-diaries
+  name: '${self:service}-${self:provider.stage}-getter-my-favorites-diaries'
+  events:
+    # API Gateway にて起動
+    - http:
+        path: /get/favorites
+        method: get
+        authorizer:
+          type: COGNITO_USER_POOLS
+          authorizerId: !Ref UnknownDiaryAuthorizer

--- a/backend/comconfirm-lambda/serverless.yml
+++ b/backend/comconfirm-lambda/serverless.yml
@@ -58,6 +58,7 @@ functions:
   - ${file(./resources/reaction-diary.yml)}
   - ${file(./resources/update-diary.yml)}
   - ${file(./resources/comment-diary.yml)}
+  - ${file(./resources/getter-my-favorites-diary.yml)}
 
 resources:
   - ${file(./resources/dynamodb.yml)}

--- a/infra/dynamodbclient/client.go
+++ b/infra/dynamodbclient/client.go
@@ -43,6 +43,21 @@ func (c *DynamoDBClient) GetAllRecords(expr *expression.Expression, exclusiveSta
 	return c.dynamo.Scan(s)
 }
 
+// GetAllRecordsWithLimit dynamoDBのレコードを指定件数取得する関数
+func (c *DynamoDBClient) GetAllRecordsWithLimit(expr *expression.Expression, exclusiveStartKey map[string]*dynamodb.AttributeValue, limit *int64) (*dynamodb.ScanOutput, error) {
+	s := &dynamodb.ScanInput{
+		// AttributesToGet:   attributesToGet,
+		TableName:                 aws.String(c.tableName),
+		FilterExpression:          expr.Filter(),
+		ExclusiveStartKey:         exclusiveStartKey,
+		ExpressionAttributeNames:  expr.Names(),
+		ExpressionAttributeValues: expr.Values(),
+		ProjectionExpression:      expr.Projection(),
+		Limit:                     limit,
+	}
+	return c.dynamo.Scan(s)
+}
+
 // QueryByExpression 検索してレコードを取得する関数
 func (c *DynamoDBClient) QueryByExpression(indexName string, expr *expression.Expression, exclusiveStartKey map[string]*dynamodb.AttributeValue) (*dynamodb.QueryOutput, error) {
 	scanIndexForwardValue := false


### PR DESCRIPTION
# 目的
- いいねした日記の一覧を見たい

# やったこと
- いいねした日記を取得するAPIを新たに作成
- いいねした日記を閲覧できるページを新たに作成

# 特記事項
- いいねした日記の詳細ページは既存のdiaryページにパスパラメータを入れ込む形で対応
- いいねした日記のページネーションのロジック→検索がfilterで行われるため少し修正を加えている