### PR TITLE
リアクションボタンに簡易アニメーションを付与

### DIFF
--- a/React/unknwon-react-diary/src/App.js
+++ b/React/unknwon-react-diary/src/App.js
@@ -48,12 +48,12 @@ function App() {
     });
   }, []);
   return (
-    <ApiContextProvider>
-      <MuiThemeProvider theme={theme}>
-        <BrowserRouter>
-          <AmplifyAuthenticator>
-            {authState === AuthState.SignedIn && user ? (
-              <div className="App">
+    <MuiThemeProvider theme={theme}>
+      <BrowserRouter>
+        <AmplifyAuthenticator>
+          {authState === AuthState.SignedIn && user ? (
+            <div className="App">
+              <ApiContextProvider>
                 <Navbar />
                 <Route exact path="/mydiary" component={MyProfile} />
                 <Route exact path="/mydiary-detail" component={MyDiaryDetail} />
@@ -62,17 +62,17 @@ function App() {
                 <Route exact path="/" component={Home} />
                 <Route exact path="/favorites" component={MyFavoritesDiaries} />
                 <Footer />
-              </div>
-            ) : (
-              <>
-                <Login />
-                <SignUp />
-              </>
-            )}
-          </AmplifyAuthenticator>
-        </BrowserRouter>
-      </MuiThemeProvider>
-    </ApiContextProvider>
+              </ApiContextProvider>
+            </div>
+          ) : (
+            <>
+              <Login />
+              <SignUp />
+            </>
+          )}
+        </AmplifyAuthenticator>
+      </BrowserRouter>
+    </MuiThemeProvider>
   );
 }
 

--- a/React/unknwon-react-diary/src/component/FetchDiary.js
+++ b/React/unknwon-react-diary/src/component/FetchDiary.js
@@ -10,6 +10,8 @@ import DialogTitle from '@material-ui/core/DialogTitle';
 import AddIcon from '@material-ui/icons/Add';
 import TextField from '@material-ui/core/TextField';
 import AddCommentIcon from '@material-ui/icons/AddComment';
+import { IconButton } from '@material-ui/core';
+import FavoriteBorder from '@material-ui/icons/FavoriteBorder';
 
 const DiaryFetch = () => {
   const location = useLocation();
@@ -19,6 +21,7 @@ const DiaryFetch = () => {
   const [isEditComment, setIsEditComment] = useState(false);
   const [leaveComment, setLeaveComment] = useState('');
   const [alreadyCommentedDialog, setAlreadyCommentedDialog] = useState(false);
+  const [favorite, setFavorite] = useState(false);
 
   const handleClickOpen = () => {
     setDialogOpen(true);
@@ -86,6 +89,7 @@ const DiaryFetch = () => {
           if (response.id === '') {
             handleClickOpen();
           }
+          console.log(response.reactioner);
         })
         .catch((err) => {
           console.log(err);
@@ -138,6 +142,7 @@ const DiaryFetch = () => {
         console.log('成功');
         console.log(diary);
         setDiary({ ...diary, reaction: response.reaction });
+        setFavorite(!favorite);
       })
       .catch((err) => {
         console.log(err);
@@ -196,8 +201,14 @@ const DiaryFetch = () => {
         </p>
         <p className="text-left mb-4 pl-3 whitespace-pre-wrap">{diary.content}</p>
         <div className="flex justify-end">
-          <FavoriteIcon className="mr-1" color="error" onClick={() => upadteDiary()} />
-          <p style={{ margin: 0, fontWeight: 'bold', fontSize: '16px' }}>{diary.reaction}</p>
+          <IconButton className="p-2" onClick={() => upadteDiary()}>
+            {favorite ? (
+              <FavoriteIcon className="mr-1" color="error" />
+            ) : (
+              <FavoriteBorder className="mr-1" color="error" />
+            )}
+          </IconButton>
+          <p className="py-2 pr-2 m-0 text-base font-bold">{diary.reaction}</p>
         </div>
       </div>
       {location.search ? (

--- a/React/unknwon-react-diary/src/component/FetchDiary.js
+++ b/React/unknwon-react-diary/src/component/FetchDiary.js
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, useContext } from 'react';
 import { useLocation } from 'react-router-dom';
 import { Auth, API } from 'aws-amplify';
 import { Grid } from '@material-ui/core';
@@ -12,8 +12,11 @@ import TextField from '@material-ui/core/TextField';
 import AddCommentIcon from '@material-ui/icons/AddComment';
 import { IconButton } from '@material-ui/core';
 import FavoriteBorder from '@material-ui/icons/FavoriteBorder';
+import { ApiContext } from '../context/ApiContext';
 
 const DiaryFetch = () => {
+  const { thisUserName } = useContext(ApiContext);
+
   const location = useLocation();
   const [diary, setDiary] = useState({});
   const [diaryContentLength, setDiaryContentLength] = useState(0);
@@ -89,14 +92,19 @@ const DiaryFetch = () => {
           if (response.id === '') {
             handleClickOpen();
           }
-          console.log(response.reactioner);
+          console.log(thisUserName);
+          if (response.reactioners === null || response.reactioners.indexOf(thisUserName) === -1) {
+            setFavorite(false);
+          } else {
+            setFavorite(true);
+          }
         })
         .catch((err) => {
           console.log(err);
         });
     };
     fetchDiary();
-  }, [location.search]);
+  }, [location.search, thisUserName]);
 
   const fetchDiary = async () => {
     const apiName = envFetchAPI();
@@ -110,10 +118,17 @@ const DiaryFetch = () => {
 
     await API.get(apiName, path, myInit)
       .then((response) => {
+        console.log(response);
         setDiary(response);
         setDiaryContentLength(response.content.length);
         if (response.id === '') {
           handleClickOpen();
+        }
+        console.log(thisUserName);
+        if (response.reactioners === null || response.reactioners.indexOf(thisUserName) === -1) {
+          setFavorite(false);
+        } else {
+          setFavorite(true);
         }
       })
       .catch((err) => {
@@ -140,9 +155,9 @@ const DiaryFetch = () => {
     await API.post(apiName, path, myInit)
       .then((response) => {
         console.log('成功');
-        console.log(diary);
-        setDiary({ ...diary, reaction: response.reaction });
+        setDiary({ ...diary, reaction: response.reaction, reactioners: response.reactioners });
         setFavorite(!favorite);
+        console.log(diary);
       })
       .catch((err) => {
         console.log(err);

--- a/React/unknwon-react-diary/src/context/ApiContext.js
+++ b/React/unknwon-react-diary/src/context/ApiContext.js
@@ -4,7 +4,7 @@ export const ApiContext = createContext();
 
 const ApiContextProvider = (props) => {
   const [myDiaryDetail, setMyDiaryDetail] = useState([]);
-  const [thisUserName, setThisUserName] = useState([]);
+  const [thisUserName, setThisUserName] = useState();
 
   useEffect(() => {
     Auth.currentUserInfo()
@@ -22,6 +22,7 @@ const ApiContextProvider = (props) => {
         myDiaryDetail,
         setMyDiaryDetail,
         thisUserName,
+        setThisUserName,
       }}
     >
       {props.children}

--- a/backend/comconfirm-lambda/functions/diary-getter/usecase/getter-job.go
+++ b/backend/comconfirm-lambda/functions/diary-getter/usecase/getter-job.go
@@ -78,6 +78,7 @@ func (gj *GetterJob) Run(ctx context.Context) (ResultDiary, error) {
 	ResultDiary.Title = getItem.Title
 	ResultDiary.Comments = getItem.Comments
 	ResultDiary.Author = getItem.Author
+	ResultDiary.Reactioners = getItem.Reactioners
 
 	return ResultDiary, nil
 

--- a/backend/comconfirm-lambda/functions/diary-my-favorites-getter/domain/get-my-favorites-diary.go
+++ b/backend/comconfirm-lambda/functions/diary-my-favorites-getter/domain/get-my-favorites-diary.go
@@ -14,12 +14,13 @@ import (
 
 // Diary - 各日記の内容を格納する構造体
 type Diary struct {
-	ID       string  `json:"id"`      // id
-	PostAt   string  `json:"post_at"` // ポストされた日時
-	Title    string  `json:"title"`   // 日記のタイトル
-	Content  string  `json:"content"` // 日記の本文
-	Date     *string `json:"date"`    // 日記の日付
-	Reaction string  `json:"reaction"`
+	ID          string   `json:"id"`      // id
+	PostAt      string   `json:"post_at"` // ポストされた日時
+	Title       string   `json:"title"`   // 日記のタイトル
+	Content     string   `json:"content"` // 日記の本文
+	Date        *string  `json:"date"`    // 日記の日付
+	Reaction    string   `json:"reaction"`
+	Reactioners []string `json:"reactioners"`
 }
 
 // GetDiaries - 日記を格納する構造体
@@ -176,6 +177,14 @@ func (gd *GetDiaries) AddDiaries(res *dynamodb.QueryOutput) ([]Diary, error) {
 			diary.Reaction = "0"
 		} else {
 			diary.Reaction = *reaction.S
+			reactioners, ok := item["reactioners"]
+			if !ok {
+				diary.Reactioners = []string{}
+			} else {
+				for _, v := range reactioners.L {
+					diary.Reactioners = append(diary.Reactioners, *v.S)
+				}
+			}
 		}
 
 		diary.ID = *item["id"].S

--- a/backend/comconfirm-lambda/functions/diary-my-getter/domain/get-my-diary.go
+++ b/backend/comconfirm-lambda/functions/diary-my-getter/domain/get-my-diary.go
@@ -14,13 +14,14 @@ import (
 
 // Diary - 各日記の内容を格納する構造体
 type Diary struct {
-	ID       string  `json:"id"`      // id
-	PostAt   string  `json:"post_at"` // ポストされた日時
-	Title    string  `json:"title"`   // 日記のタイトル
-	Content  string  `json:"content"` // 日記の本文
-	Date     *string `json:"date"`    // 日記の日付
-	Reaction string  `json:"reaction"`
-	Author   string  `json:"author"`
+	ID          string   `json:"id"`      // id
+	PostAt      string   `json:"post_at"` // ポストされた日時
+	Title       string   `json:"title"`   // 日記のタイトル
+	Content     string   `json:"content"` // 日記の本文
+	Date        *string  `json:"date"`    // 日記の日付
+	Reaction    string   `json:"reaction"`
+	Author      string   `json:"author"`
+	Reactioners []string `json:"reactioners"`
 }
 
 // GetDiaries - 日記を格納する構造体
@@ -170,6 +171,14 @@ func (gd *GetDiaries) AddDiaries(res *dynamodb.QueryOutput) ([]Diary, error) {
 			diary.Reaction = "0"
 		} else {
 			diary.Reaction = *reaction.S
+			reactioners, ok := item["reactioners"]
+			if !ok {
+				diary.Reactioners = []string{}
+			} else {
+				for _, v := range reactioners.L {
+					diary.Reactioners = append(diary.Reactioners, *v.S)
+				}
+			}
 		}
 
 		diary.ID = *item["id"].S

--- a/backend/comconfirm-lambda/serverless.yml
+++ b/backend/comconfirm-lambda/serverless.yml
@@ -4,7 +4,7 @@ provider:
   name: aws
   runtime: go1.x
   region: ap-northeast-1
-#   profile: amagai
+  profile: amagai
   stage: ${opt:stage, "dev"}
 
   environment:


### PR DESCRIPTION
# 目的
- 取得した日記に対してユーザーが既にリアクションしているかどうかがわかりづらかったので、リアクション済かどうかで初期ハートアイコンを出し分けたい。
- また、いいねを押した際に押したことがわかりやすくなるようにアニメーションをつけたい

# やったこと
- material-uiのコンポーネントを作成し出しわけした
- バックエンドのレスポンスにreactionersを追加した
- 日記取得時に取得ユーザーがreactioners配列に含まれていなければ赤枠のハート、そうでなければ塗り潰したハートを表示させた。リアクションAPIが成功するごとにこれらを出し分けた。

# 特記事項
- 決してリッチなアニメーションではない.
- 自分自身のユーザー名をグローバルstateで管理するため、APIContextコンポーネントの範囲からLogout,SignOutコンポーネントから外した